### PR TITLE
Command to execute noninteractive shell commands

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,5 +1,6 @@
 recursive: true
 reporter: spec
 require: ts-node/register
+slow: 600
 timeout: 7500
 watch-extensions: ts

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
     "editor.formatOnSave": true,
     "editor.formatOnSaveMode": "file"
   },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "files.trimFinalNewlines": true,
   "typescript.format.enable": true,
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.1.0...HEAD)
+- `borealis-pg:run` command to execute a noninteractive shell command for an add-on database
+
 ## [0.1.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/477321d...v0.1.0) - 2021-09-24
 First public pre-release version

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "repository": "OldSneerJaw/borealis-pg-cli",
   "scripts": {
     "clean": "rm -rf node_modules",
-    "lint": "eslint . --ext .ts --config .eslintrc",
+    "lint": "eslint --max-warnings 0 --ext .ts --config .eslintrc .",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "nyc mocha --forbid-only \"**/*.test.ts\"",

--- a/src/command-components.test.ts
+++ b/src/command-components.test.ts
@@ -5,9 +5,9 @@ import {anyString, instance, mock, verify} from 'ts-mockito'
 import {consoleColours, processAddonAttachmentInfo} from './command-components'
 
 describe('processAddonAttachmentInfo', () => {
-  const fakeAddonAttachmentName = 'MY_SWELL_DB'
-  const fakeAppName = 'my-swell-app'
-  const fakeAddonName = 'my-swell-addon'
+  const fakeAddonAttachmentName = 'MY_NEAT_DB'
+  const fakeAppName = 'my-neat-app'
+  const fakeAddonName = 'my-neat-addon'
 
   let errorHandlerMockType: {func: ((message: string) => never)}
   let errorHandlerMockInstance: typeof errorHandlerMockType
@@ -19,34 +19,51 @@ describe('processAddonAttachmentInfo', () => {
 
   it('returns the first entry when there are multiple', () => {
     const fakeAttachments: AddOnAttachment[] = [
-      {addon: {app: {}, id: '#1', name: fakeAddonName}, id: fakeAddonAttachmentName},
-      {addon: {app: {}, id: '#2', name: 'another-addon'}, id: 'another-attachment'},
+      {
+        addon: {app: {}, id: '#1', name: fakeAddonName},
+        app: {name: fakeAppName},
+        name: fakeAddonAttachmentName,
+      },
+      {
+        addon: {app: {}, id: '#2', name: 'another-addon'},
+        app: {name: 'another-app'},
+        name: 'another-attachment',
+      },
     ]
 
     const result = processAddonAttachmentInfo(
-      errorHandlerMockInstance.func,
       fakeAttachments,
-      fakeAddonName,
-    )
+      {addonOrAttachment: fakeAddonName},
+      errorHandlerMockInstance.func)
 
-    expect(result).to.equal(fakeAddonName)
+    expect(result).to.deep.equal({
+      addonName: fakeAddonName,
+      appName: fakeAppName,
+      attachmentName: fakeAddonAttachmentName,
+    })
 
     verify(errorHandlerMockType.func(anyString())).never()
   })
 
   it('returns the first entry when there is only one', () => {
     const fakeAttachments: AddOnAttachment[] = [
-      {addon: {app: {}, id: '#1', name: fakeAddonName}, id: fakeAddonAttachmentName},
+      {
+        addon: {app: {}, id: '#1', name: fakeAddonName},
+        app: {name: fakeAppName},
+        name: fakeAddonAttachmentName,
+      },
     ]
 
     const result = processAddonAttachmentInfo(
-      errorHandlerMockInstance.func,
       fakeAttachments,
-      fakeAddonAttachmentName,
-      fakeAppName,
-    )
+      {addonOrAttachment: fakeAddonAttachmentName, app: fakeAppName},
+      errorHandlerMockInstance.func)
 
-    expect(result).to.equal(fakeAddonName)
+    expect(result).to.deep.equal({
+      addonName: fakeAddonName,
+      appName: fakeAppName,
+      attachmentName: fakeAddonAttachmentName,
+    })
 
     verify(errorHandlerMockType.func(anyString())).never()
   })
@@ -57,11 +74,9 @@ describe('processAddonAttachmentInfo', () => {
       'attachment'
 
     const result = processAddonAttachmentInfo(
-      errorHandlerMockInstance.func,
       null,
-      fakeAddonAttachmentName,
-      fakeAppName,
-    )
+      {addonOrAttachment: fakeAddonAttachmentName, app: fakeAppName},
+      errorHandlerMockInstance.func)
 
     expect(result).not.to.exist
 
@@ -74,10 +89,9 @@ describe('processAddonAttachmentInfo', () => {
       `${consoleColours.cliFlagName('--app')} flag.`
 
     const result = processAddonAttachmentInfo(
-      errorHandlerMockInstance.func,
       null,
-      fakeAddonName,
-    )
+      {addonOrAttachment: fakeAddonName},
+      errorHandlerMockInstance.func)
 
     expect(result).not.to.exist
 
@@ -89,11 +103,9 @@ describe('processAddonAttachmentInfo', () => {
     const expectedMessage = 'Add-on service is temporarily unavailable. Try again later.'
 
     const result = processAddonAttachmentInfo(
-      errorHandlerMockInstance.func,
       fakeAttachments,
-      fakeAddonAttachmentName,
-      fakeAppName,
-    )
+      {addonOrAttachment: fakeAddonAttachmentName, app: fakeAppName},
+      errorHandlerMockInstance.func)
 
     expect(result).not.to.exist
 
@@ -104,10 +116,9 @@ describe('processAddonAttachmentInfo', () => {
     const fakeAttachments: AddOnAttachment[] = []
 
     const result = processAddonAttachmentInfo(
-      errorHandlerMockInstance.func,
       fakeAttachments,
-      fakeAddonName,
-    )
+      {addonOrAttachment: fakeAddonName},
+      errorHandlerMockInstance.func)
 
     expect(result).not.to.exist
 

--- a/src/command-components.ts
+++ b/src/command-components.ts
@@ -4,6 +4,7 @@ import {AddOnAttachment} from '@heroku-cli/schema'
 
 export const consoleColours = {
   cliFlagName: color.bold.italic,
+  envVar: color.bold,
   pgExtension: color.green,
 }
 
@@ -51,35 +52,40 @@ export const cliFlags = {
 }
 
 /**
- * Retrieves the add-on name associated with the given attachment info list
+ * Retrieves various add-on info for the first entry in the given attachment info list
  *
- * @param errorHandler A function to output errors when they occur
  * @param attachmentInfos A list of attachment information
- * @param addonOrAttachment The ID or name of an add-on or one of its attachments
- * @param appName The name of the app to which the add-on is attached
+ * @param addonFilter The filter that was used to fetch the attachment info list
+ * @param errorHandler A function to output errors when they occur
  *
- * @returns The add-on name
+ * @returns Info about the corresponding add-on
  */
 export function processAddonAttachmentInfo(
-  errorHandler: (message: string) => never,
   attachmentInfos: AddOnAttachment[] | null,
-  addonOrAttachment: string,
-  appName?: string): string | never {
+  addonFilter: {addonOrAttachment: string; app?: string},
+  errorHandler: (message: string) => never): {
+    addonName: string;
+    appName: string;
+    attachmentName: string;
+  } | never {
   if (attachmentInfos && attachmentInfos.length > 0) {
     const [attachmentInfo] = attachmentInfos
 
     const addonName = attachmentInfo.addon?.name
-    if (addonName) {
-      return addonName
+    const appName = attachmentInfo.app?.name
+    const attachmentName = attachmentInfo.name
+    if (addonName && appName && attachmentName) {
+      return {addonName, appName, attachmentName}
     } else {
       errorHandler('Add-on service is temporarily unavailable. Try again later.')
     }
-  } else if (appName) {
+  } else if (addonFilter.app) {
     return errorHandler(
-      `App ${color.app(appName)} has no ${color.addon(addonOrAttachment)} add-on attachment`)
+      `App ${color.app(addonFilter.app)} has no ${color.addon(addonFilter.addonOrAttachment)} ` +
+      'add-on attachment')
   } else {
     return errorHandler(
-      `Add-on ${color.addon(addonOrAttachment)} was not found. Consider trying again with the ` +
-      `${consoleColours.cliFlagName('--app')} flag.`)
+      `Add-on ${color.addon(addonFilter.addonOrAttachment)} was not found. Consider trying again ` +
+      `with the ${consoleColours.cliFlagName('--app')} flag.`)
   }
 }

--- a/src/commands/borealis-pg/extensions/index.ts
+++ b/src/commands/borealis-pg/extensions/index.ts
@@ -20,8 +20,10 @@ export default class ListPgExtensionsCommand extends Command {
     const {flags} = this.parse(ListPgExtensionsCommand)
     const authorization = await createHerokuAuth(this.heroku)
     const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const addonName =
-      processAddonAttachmentInfo(this.error, attachmentInfos, flags.addon, flags.app)
+    const {addonName} = processAddonAttachmentInfo(
+      attachmentInfos,
+      {addonOrAttachment: flags.addon, app: flags.app},
+      this.error)
     try {
       const response = await applyActionSpinner(
         `Fetching Postgres extension list for add-on ${color.addon(addonName)}`,

--- a/src/commands/borealis-pg/extensions/install.ts
+++ b/src/commands/borealis-pg/extensions/install.ts
@@ -47,8 +47,10 @@ export default class InstallPgExtensionsCommand extends Command {
     const pgExtension = args[cliArgs.pgExtension.name]
     const authorization = await createHerokuAuth(this.heroku)
     const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const addonName =
-      processAddonAttachmentInfo(this.error, attachmentInfos, flags.addon, flags.app)
+    const {addonName} = processAddonAttachmentInfo(
+      attachmentInfos,
+      {addonOrAttachment: flags.addon, app: flags.app},
+      this.error)
     try {
       const extSchemas = await applyActionSpinner(
         `Installing Postgres extension ${pgExtensionColour(pgExtension)} for add-on ${color.addon(addonName)}`,

--- a/src/commands/borealis-pg/extensions/remove.test.ts
+++ b/src/commands/borealis-pg/extensions/remove.test.ts
@@ -89,7 +89,7 @@ describe('extension removal command', () => {
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
       api => api.delete(`/heroku/resources/${fakeAddonName}/pg-extensions/${fakeExt1}`)
         .reply(200, {success: true}))
-    .stdin(` ${fakeExt1} `, 250) // Fakes keyboard input for the confirmation prompt
+    .stdin(` ${fakeExt1} `, 500) // Fakes keyboard input for the confirmation prompt
     .command(['borealis-pg:extensions:remove', '-o', fakeAddonName, fakeExt1])
     .it('removes the requested extension after a successful confirmation prompt', ctx => {
       expect(ctx.stderr).to.endWith(
@@ -99,7 +99,7 @@ describe('extension removal command', () => {
 
   test.stdout()
     .stderr()
-    .stdin('WRONG!', 250) // Fakes keyboard input for the confirmation prompt
+    .stdin('WRONG!', 500) // Fakes keyboard input for the confirmation prompt
     .command(['borealis-pg:extensions:remove', '-o', fakeAddonName, fakeExt2])
     .catch(/^Invalid confirmation provided/)
     .it('exits with an error if the confirmation prompt fails', ctx => {

--- a/src/commands/borealis-pg/extensions/remove.ts
+++ b/src/commands/borealis-pg/extensions/remove.ts
@@ -46,8 +46,10 @@ export default class RemovePgExtensionCommand extends Command {
 
     const authorization = await createHerokuAuth(this.heroku)
     const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const addonName =
-      processAddonAttachmentInfo(this.error, attachmentInfos, flags.addon, flags.app)
+    const {addonName} = processAddonAttachmentInfo(
+      attachmentInfos,
+      {addonOrAttachment: flags.addon, app: flags.app},
+      this.error)
 
     try {
       await applyActionSpinner(

--- a/src/commands/borealis-pg/run.test.ts
+++ b/src/commands/borealis-pg/run.test.ts
@@ -1,0 +1,851 @@
+import color from '@heroku-cli/color'
+import {ChildProcess} from 'child_process'
+import {Server, Socket} from 'net'
+import {Client as SshClient, ClientChannel} from 'ssh2'
+import internal from 'stream'
+import {
+  anyFunction,
+  anyNumber,
+  anyString,
+  anything,
+  capture,
+  deepEqual,
+  instance,
+  mock,
+  verify,
+  when,
+} from 'ts-mockito'
+import {borealisPgApiBaseUrl, expect, herokuApiBaseUrl, test} from '../../test-utils'
+import tunnelServices from '../../tunnel-services'
+
+const localPgHostname = 'localhost'
+const defaultSshPort = 22
+const customSshPort = 50022
+const defaultPgPort = 5432
+const customPgPort = 65432
+
+const fakeAddonName = 'borealis-pg-my-fake-addon'
+const fakeAddonAttachmentName = 'MY_COOL_DB'
+const fakeHerokuAppName = 'my-fake-heroku-app'
+const fakeHerokuAuthToken = 'my-fake-heroku-auth-token'
+const fakeHerokuAuthId = 'my-fake-heroku-auth'
+
+const fakeSshHost = 'my-fake-ssh-hostname'
+const fakeSshUsername = 'ssh-test-user'
+const fakeSshPrivateKey = 'my-fake-ssh-private-key'
+const fakePgWriterHost = 'my-fake-pg-writer-hostname'
+const fakePgReaderHost = 'my-fake-pg-reader-hostname'
+const fakePgReadWriteAppUsername = 'app_rw_db_test_user'
+const fakePgReadWriteAppPassword = 'my-fake-db-writer-password'
+const fakePgReadonlyAppUsername = 'app_ro_db_test_user'
+const fakePgReadonlyAppPassword = 'my-fake-db-reader-password'
+const fakePgPersonalUsername = 'personal_db_test_user'
+const fakePgPersonalPassword = 'my-fake-personal-db-password'
+const fakePgDbName = 'fake_db'
+
+const expectedSshHostKeyFormat = 'ssh-ed25519'
+const expectedSshHostKey = 'AAAAC3NzaC1lZDI1NTE5AAAAIKkk9uh8+g/gKlLlbi4sVv4VJkiaLjYOJj+wVVyTGzhI'
+const expectedSshHostKeyEntry = `${expectedSshHostKeyFormat} ${expectedSshHostKey}`
+
+const fakeAppConfigVars: {[name: string]: string} = {FOO_BAR: 'baz'}
+
+fakeAppConfigVars[`${fakeAddonAttachmentName}_URL`] =
+  `postgres://${fakePgReadWriteAppUsername}:${fakePgReadWriteAppPassword}@` +
+  `${localPgHostname}:${customPgPort}/${fakePgDbName}`
+
+fakeAppConfigVars[`${fakeAddonAttachmentName}_READONLY_URL`] =
+  `postgres://${fakePgReadonlyAppUsername}:${fakePgReadonlyAppPassword}@` +
+  `${localPgHostname}:${customPgPort}/${fakePgDbName}`
+
+fakeAppConfigVars[`${fakeAddonAttachmentName}_SSH_TUNNEL_BPG_CONNECTION_INFO`] =
+  `POSTGRES_WRITER_HOST:=${fakePgWriterHost}|` +
+  `POSTGRES_READER_HOST:=${fakePgReaderHost}|` +
+  `POSTGRES_PORT:=${customPgPort}|` +
+  `POSTGRES_DB_NAME:=${fakePgDbName}|` +
+  `POSTGRES_WRITER_USERNAME:=${fakePgReadWriteAppUsername}|` +
+  `POSTGRES_WRITER_PASSWORD:=${fakePgReadWriteAppPassword}|` +
+  `POSTGRES_READER_USERNAME:=${fakePgReadonlyAppUsername}|` +
+  `POSTGRES_READER_PASSWORD:=${fakePgReadonlyAppPassword}|` +
+  'SSH_HOST:=this-ssh-hostname-should-be-ignored|' +
+  'SSH_PORT:=10101|' +
+  'SSH_PUBLIC_HOST_KEY:=this-ssh-host-key-should-be-ignored|' +
+  'SSH_USERNAME:=this-ssh-username-should-be-ignored|' +
+  'SSH_USER_PRIVATE_KEY:=this-ssh-private-key-should-be-ignored'
+
+const fakeShellCommand = 'my-cool-shell-command'
+
+const baseTestContext = test.stdout()
+  .stderr()
+  .nock(herokuApiBaseUrl, api => api
+    .post('/oauth/authorizations', {
+      description: 'Borealis PG CLI plugin temporary auth token',
+      expires_in: 180,
+      scope: ['read', 'identity'],
+    })
+    .reply(201, {id: fakeHerokuAuthId, access_token: {token: fakeHerokuAuthToken}})
+    .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
+    .reply(200))
+
+const testContextWithAppConfigVars = baseTestContext
+  .nock(herokuApiBaseUrl, api => api.get(`/apps/${fakeHerokuAppName}/config-vars`)
+    .reply(200, fakeAppConfigVars))
+
+const testContextWithDefaultUsers = testContextWithAppConfigVars
+  .nock(
+    borealisPgApiBaseUrl,
+    {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+    api => api.post(`/heroku/resources/${fakeAddonName}/personal-ssh-users`)
+      .reply(
+        200,
+        {
+          sshHost: fakeSshHost,
+          sshPort: customSshPort,
+          sshUsername: fakeSshUsername,
+          sshPrivateKey: fakeSshPrivateKey,
+          publicSshHostKey: expectedSshHostKeyEntry,
+        }))
+
+const defaultTestContext = testContextWithDefaultUsers
+  .nock(herokuApiBaseUrl, api => api
+    .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+    .reply(200, [
+      {
+        addon: {name: fakeAddonName},
+        app: {name: fakeHerokuAppName},
+        name: fakeAddonAttachmentName,
+      },
+      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
+    ]))
+
+const testContextWithAppFlag = testContextWithDefaultUsers
+  .nock(herokuApiBaseUrl, api => api
+    .post(
+      '/actions/addon-attachments/resolve',
+      {addon_attachment: fakeAddonAttachmentName, app: fakeHerokuAppName})
+    .reply(200, [
+      {
+        addon: {name: fakeAddonName},
+        app: {name: fakeHerokuAppName},
+        name: fakeAddonAttachmentName,
+      },
+    ]))
+
+const testContextWithWriteAccess = testContextWithAppConfigVars
+  .nock(
+    borealisPgApiBaseUrl,
+    {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+    api => api.post(`/heroku/resources/${fakeAddonName}/personal-ssh-users`)
+      .reply(
+        200,
+        {
+          sshHost: fakeSshHost,
+          sshPort: defaultSshPort,
+          sshUsername: fakeSshUsername,
+          sshPrivateKey: fakeSshPrivateKey,
+          publicSshHostKey: expectedSshHostKeyEntry,
+        }))
+  .nock(herokuApiBaseUrl, api => api
+    .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+    .reply(200, [
+      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: fakeAddonAttachmentName},
+    ]))
+
+const testContextWithPersonalUser = baseTestContext
+  .nock(
+    borealisPgApiBaseUrl,
+    {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+    api => api.post(`/heroku/resources/${fakeAddonName}/personal-ssh-users`)
+      .reply(
+        200,
+        {
+          sshHost: fakeSshHost,
+          sshPort: defaultSshPort,
+          sshUsername: fakeSshUsername,
+          sshPrivateKey: fakeSshPrivateKey,
+          publicSshHostKey: expectedSshHostKeyEntry,
+        })
+      .post(`/heroku/resources/${fakeAddonName}/personal-db-users`)
+      .reply(
+        200,
+        {
+          dbHost: fakePgReaderHost,
+          dbPort: customPgPort,
+          dbName: fakePgDbName,
+          dbUsername: fakePgPersonalUsername,
+          dbPassword: fakePgPersonalPassword,
+        }))
+  .nock(herokuApiBaseUrl, api => api
+    .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+    .reply(200, [
+      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: fakeAddonAttachmentName},
+    ]))
+
+describe('noninteractive run command', () => {
+  let originalChildProcessFactory: typeof tunnelServices.childProcessFactory
+  let originalNodeProcess: typeof tunnelServices.nodeProcess
+  let originalTcpServerFactory: typeof tunnelServices.tcpServerFactory
+  let originalSshClientFactory: typeof tunnelServices.sshClientFactory
+
+  let mockChildProcessFactoryType: typeof tunnelServices.childProcessFactory
+  let mockChildProcessType: ChildProcess
+  let mockChildProcessStdoutType: internal.Readable
+  let mockChildProcessStderrType: internal.Readable
+
+  let mockNodeProcessType: NodeJS.Process
+
+  let mockTcpServerFactoryType: typeof tunnelServices.tcpServerFactory
+  let mockTcpServerType: Server
+
+  let mockSshClientFactoryType: typeof tunnelServices.sshClientFactory
+  let mockSshClientType: SshClient
+
+  let mockTcpSocketType: Socket
+  let mockTcpSocketInstance: Socket
+
+  let mockSshStreamType: ClientChannel
+  let mockSshStreamInstance: ClientChannel
+
+  beforeEach(() => {
+    originalChildProcessFactory = tunnelServices.childProcessFactory
+    originalNodeProcess = tunnelServices.nodeProcess
+    originalTcpServerFactory = tunnelServices.tcpServerFactory
+    originalSshClientFactory = tunnelServices.sshClientFactory
+
+    mockChildProcessStdoutType = mock()
+    mockChildProcessStderrType = mock()
+
+    mockChildProcessType = mock()
+    when(mockChildProcessType.stdout).thenReturn(instance(mockChildProcessStdoutType))
+    when(mockChildProcessType.stderr).thenReturn(instance(mockChildProcessStderrType))
+    const mockChildProcessInstance = instance(mockChildProcessType)
+    when(mockChildProcessType.on(anyString(), anyFunction())).thenReturn(mockChildProcessInstance)
+
+    mockChildProcessFactoryType = mock()
+    when(mockChildProcessFactoryType.spawn(anyString(), anything()))
+      .thenReturn(mockChildProcessInstance)
+    tunnelServices.childProcessFactory = instance(mockChildProcessFactoryType)
+
+    mockNodeProcessType = mock()
+    const mockNodeProcessInstance = instance(mockNodeProcessType)
+    mockNodeProcessInstance.env = {FOO_EXAMPLE: 'BAR'}
+    tunnelServices.nodeProcess = mockNodeProcessInstance
+
+    mockTcpServerType = mock(Server)
+    const mockTcpServerInstance = instance(mockTcpServerType)
+    when(mockTcpServerType.on(anyString(), anyFunction())).thenReturn(mockTcpServerInstance)
+    when(mockTcpServerType.listen(anyNumber(), anyString())).thenReturn(mockTcpServerInstance)
+    when(mockTcpServerType.close()).thenReturn(mockTcpServerInstance)
+
+    mockTcpServerFactoryType = mock()
+    when(mockTcpServerFactoryType.create(anyFunction())).thenReturn(mockTcpServerInstance)
+    tunnelServices.tcpServerFactory = instance(mockTcpServerFactoryType)
+
+    mockSshClientType = mock(SshClient)
+    const mockSshClientInstance = instance(mockSshClientType)
+    when(mockSshClientType.on(anyString(), anyFunction())).thenReturn(mockSshClientInstance)
+
+    mockSshClientFactoryType = mock()
+    when(mockSshClientFactoryType.create()).thenReturn(mockSshClientInstance)
+    tunnelServices.sshClientFactory = instance(mockSshClientFactoryType)
+
+    mockTcpSocketType = mock(Socket)
+    mockTcpSocketInstance = instance(mockTcpSocketType)
+    when(mockTcpSocketType.on(anyString(), anyFunction())).thenReturn(mockTcpSocketInstance)
+    when(mockTcpSocketType.pipe(anything())).thenReturn(mockTcpSocketInstance)
+
+    mockSshStreamType = mock()
+    mockSshStreamInstance = instance(mockSshStreamType)
+    when(mockSshStreamType.on(anyString(), anyFunction())).thenReturn(mockSshStreamInstance)
+    when(mockSshStreamType.pipe(anything())).thenReturn(mockSshStreamInstance)
+  })
+
+  afterEach(() => {
+    tunnelServices.childProcessFactory = originalChildProcessFactory
+    tunnelServices.nodeProcess = originalNodeProcess
+    tunnelServices.sshClientFactory = originalSshClientFactory
+    tunnelServices.tcpServerFactory = originalTcpServerFactory
+  })
+
+  defaultTestContext
+    .command(['borealis-pg:run', '--addon', fakeAddonName, '--shell-command', fakeShellCommand])
+    .it('starts the proxy server', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).once()
+      verify(mockTcpServerType.on(anyString(), anyFunction())).once()
+      verify(mockTcpServerType.on('error', anyFunction())).once()
+      verify(mockTcpServerType.listen(anyNumber(), anyString())).once()
+      verify(mockTcpServerType.listen(defaultPgPort, localPgHostname)).once()
+    })
+
+  defaultTestContext
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .it('connects to the SSH server', () => {
+      verify(mockSshClientFactoryType.create()).once()
+      verify(mockSshClientType.on(anyString(), anyFunction())).once()
+      verify(mockSshClientType.on('ready', anyFunction())).once()
+
+      verify(mockSshClientType.connect(anything())).once()
+      const [connectConfig] = capture(mockSshClientType.connect).last()
+      expect(connectConfig.host).to.equal(fakeSshHost)
+      expect(connectConfig.port).to.equal(customSshPort)
+      expect(connectConfig.username).to.equal(fakeSshUsername)
+      expect(connectConfig.privateKey).to.equal(fakeSshPrivateKey)
+      expect(connectConfig.algorithms).to.deep.equal({serverHostKey: [expectedSshHostKeyFormat]})
+
+      expect(connectConfig.hostVerifier).to.exist
+      const hostVerifier = connectConfig.hostVerifier as ((keyHash: unknown) => boolean)
+      expect(hostVerifier(expectedSshHostKey)).to.be.true
+      expect(hostVerifier('no good!')).to.be.false
+    })
+
+  defaultTestContext
+    .command(['borealis-pg:run', '--addon', fakeAddonName, '--shell-command', fakeShellCommand])
+    .it('executes the shell command without a DB port flag', ctx => {
+      executeSshClientListener()
+
+      verify(mockChildProcessFactoryType.spawn(
+        fakeShellCommand,
+        deepEqual({
+          env: {
+            ...tunnelServices.nodeProcess.env,
+            PGHOST: localPgHostname,
+            PGPORT: defaultPgPort.toString(),
+            PGDATABASE: fakePgDbName,
+            PGUSER: fakePgReadonlyAppUsername,
+            PGPASSWORD: fakePgReadonlyAppPassword,
+            DATABASE_URL:
+              `postgres://${fakePgReadonlyAppUsername}:${fakePgReadonlyAppPassword}@` +
+              `${localPgHostname}:${defaultPgPort}/${fakePgDbName}`,
+          },
+          shell: true,
+          stdio: ['ignore', null, null],
+        }))).once()
+
+      // Check that the child process's stdout is written to this process's stdout
+      const fakeStdoutMessage = 'my-stdout-message'
+
+      verify(mockChildProcessType.stdout).atLeast(1)
+      verify(mockChildProcessStdoutType.on(anyString(), anyFunction())).once()
+
+      const [childStdoutEvent, childStdoutListener] = capture(mockChildProcessStdoutType.on).last()
+      expect(childStdoutEvent).to.equal('data')
+
+      childStdoutListener(fakeStdoutMessage)
+
+      expect(ctx.stdout).to.endWith(`${fakeStdoutMessage}\n`)
+
+      // Check that the child process's stderr is written to this process's stderr
+      const fakeStderrMessage = 'my-stderr-message'
+
+      verify(mockChildProcessType.stderr).atLeast(1)
+      verify(mockChildProcessStderrType.on(anyString(), anyFunction())).once()
+
+      const [childStderrEvent, childStderrListener] = capture(mockChildProcessStderrType.on).last()
+      expect(childStderrEvent).to.equal('data')
+
+      childStderrListener(fakeStderrMessage)
+
+      expect(ctx.stderr).to.endWith(`${fakeStderrMessage}\n`)
+
+      // Check what happens when the child process ends with an exit code
+      const fakeExitCode = 14
+
+      verify(mockChildProcessType.on(anyString(), anyFunction())).once()
+
+      const [childProcEvent, childProcListener] = capture(mockChildProcessType.on).last()
+      expect(childProcEvent).to.equal('exit')
+
+      const childProcExitListener: (code: number | null, _: any) => void = childProcListener
+
+      childProcExitListener(fakeExitCode, null)
+
+      verify(mockSshClientType.end()).once()
+      verify(mockNodeProcessType.exit(fakeExitCode))
+    })
+
+  defaultTestContext
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-p', '2345', '-e', fakeShellCommand])
+    .it('executes the shell command with a custom DB port flag', () => {
+      executeSshClientListener()
+
+      verify(mockChildProcessFactoryType.spawn(
+        fakeShellCommand,
+        deepEqual({
+          env: {
+            ...tunnelServices.nodeProcess.env,
+            PGHOST: localPgHostname,
+            PGPORT: '2345',
+            PGDATABASE: fakePgDbName,
+            PGUSER: fakePgReadonlyAppUsername,
+            PGPASSWORD: fakePgReadonlyAppPassword,
+            DATABASE_URL:
+              `postgres://${fakePgReadonlyAppUsername}:${fakePgReadonlyAppPassword}@` +
+              `${localPgHostname}:2345/${fakePgDbName}`,
+          },
+          shell: true,
+          stdio: ['ignore', null, null],
+        }))).once()
+
+      verify(mockChildProcessStdoutType.on('data', anyFunction())).once()
+      verify(mockChildProcessStderrType.on('data', anyFunction())).once()
+
+      // Check what happens when the child process ends without an exit code
+      verify(mockChildProcessType.on(anyString(), anyFunction())).once()
+
+      const [childProcEvent, childProcListener] = capture(mockChildProcessType.on).last()
+      expect(childProcEvent).to.equal('exit')
+
+      const childProcExitListener: (code: number | null, _: any) => void = childProcListener
+
+      childProcExitListener(null, null)
+
+      verify(mockSshClientType.end()).once()
+      verify(mockNodeProcessType.exit(undefined))
+    })
+
+  defaultTestContext
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .it('executes the shell command even when the child process has no stdout or stderr', () => {
+      when(mockChildProcessType.stdout).thenReturn(null)
+      when(mockChildProcessType.stderr).thenReturn(null)
+
+      executeSshClientListener()
+
+      verify(mockChildProcessFactoryType.spawn(fakeShellCommand, anything())).once()
+      verify(mockChildProcessStdoutType.on(anyString(), anyFunction())).never()
+      verify(mockChildProcessStderrType.on(anyString(), anyFunction())).never()
+    })
+
+  testContextWithAppFlag
+    .command([
+      'borealis-pg:run',
+      '-a',
+      fakeHerokuAppName,
+      '-o',
+      fakeAddonAttachmentName,
+      '-e',
+      fakeShellCommand,
+    ])
+    .it('finds the correct add-on using its app and attachment names', ctx => {
+      executeSshClientListener()
+
+      expect(ctx.stderr).to.endWith(
+        `Configuring user session for add-on ${fakeAddonName}... done\n`)
+      verify(mockChildProcessFactoryType.spawn(fakeShellCommand, anything())).once()
+    })
+
+  testContextWithWriteAccess
+    .command([
+      'borealis-pg:run',
+      '--addon',
+      fakeAddonName,
+      '--write-access',
+      '--shell-command',
+      fakeShellCommand,
+    ])
+    .it('configures the DB user with write access when requested', () => {
+      executeSshClientListener()
+
+      verify(mockChildProcessFactoryType.spawn(
+        fakeShellCommand,
+        deepEqual({
+          env: {
+            ...tunnelServices.nodeProcess.env,
+            PGHOST: localPgHostname,
+            PGPORT: defaultPgPort.toString(),
+            PGDATABASE: fakePgDbName,
+            PGUSER: fakePgReadWriteAppUsername,
+            PGPASSWORD: fakePgReadWriteAppPassword,
+            DATABASE_URL:
+              `postgres://${fakePgReadWriteAppUsername}:${fakePgReadWriteAppPassword}@` +
+              `${localPgHostname}:${defaultPgPort}/${fakePgDbName}`,
+          },
+          shell: true,
+          stdio: ['ignore', null, null],
+        }))).once()
+    })
+
+  testContextWithPersonalUser
+    .command([
+      'borealis-pg:run',
+      '--personal-user',
+      '--addon',
+      fakeAddonName,
+      '--shell-command',
+      fakeShellCommand,
+    ])
+    .it('uses a personal DB user when requested', () => {
+      executeSshClientListener()
+
+      verify(mockChildProcessFactoryType.spawn(
+        fakeShellCommand,
+        deepEqual({
+          env: {
+            ...tunnelServices.nodeProcess.env,
+            PGHOST: localPgHostname,
+            PGPORT: defaultPgPort.toString(),
+            PGDATABASE: fakePgDbName,
+            PGUSER: fakePgPersonalUsername,
+            PGPASSWORD: fakePgPersonalPassword,
+            DATABASE_URL:
+              `postgres://${fakePgPersonalUsername}:${fakePgPersonalPassword}@` +
+              `${localPgHostname}:${defaultPgPort}/${fakePgDbName}`,
+          },
+          shell: true,
+          stdio: ['ignore', null, null],
+        }))).once()
+    })
+
+  defaultTestContext
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .it('starts SSH port forwarding', () => {
+      const [tcpConnectionListener] = capture(mockTcpServerFactoryType.create).last()
+      tcpConnectionListener(mockTcpSocketInstance)
+
+      verify(mockSshClientType.forwardOut(
+        localPgHostname,
+        defaultPgPort,
+        fakePgReaderHost,
+        customPgPort,
+        anyFunction())).once()
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [_, _1, _2, _3, portForwardListener] = capture(mockSshClientType.forwardOut).last()
+      portForwardListener(undefined, mockSshStreamInstance)
+
+      verify(mockTcpSocketType.pipe(mockSshStreamInstance)).once()
+      verify(mockSshStreamType.pipe(mockTcpSocketInstance)).once()
+
+      verify(mockTcpSocketType.on(anyString(), anyFunction())).twice()
+      verify(mockTcpSocketType.on('end', anyFunction())).once()
+      verify(mockTcpSocketType.on('error', anyFunction())).once()
+    })
+
+  test
+    .stdout()
+    .stderr()
+    .command([
+      'borealis-pg:run',
+      '--addon',
+      fakeAddonName,
+      '--port',
+      'port-must-be-an-integer',
+      '--shell-command',
+      fakeShellCommand,
+    ])
+    .catch('Value "port-must-be-an-integer" is not a valid integer')
+    .it('rejects a --port value that is not an integer', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).never()
+      verify(mockSshClientFactoryType.create()).never()
+    })
+
+  test
+    .stdout()
+    .stderr()
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-p', '-1', '-e', fakeShellCommand])
+    .catch('Value -1 is outside the range of valid port numbers')
+    .it('rejects a --port value that is less than 1', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).never()
+      verify(mockSshClientFactoryType.create()).never()
+    })
+
+  test
+    .stdout()
+    .stderr()
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-p', '65536', '-e', fakeShellCommand])
+    .catch('Value 65536 is outside the range of valid port numbers')
+    .it('rejects a --port value that is greater than 65535', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).never()
+      verify(mockSshClientFactoryType.create()).never()
+    })
+
+  test.stdout()
+    .stderr()
+    .nock(
+      herokuApiBaseUrl,
+      api => api.post('/oauth/authorizations')
+        .reply(201, {id: fakeHerokuAuthId})  // The access_token field is missing
+        .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
+        .reply(200)
+        .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+        .reply(200, [
+          {
+            addon: {name: fakeAddonName},
+            app: {name: fakeHerokuAppName},
+            name: fakeAddonAttachmentName,
+          },
+        ]))
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .catch('Log in to the Heroku CLI first!')
+    .it('exits with an error if there is no Heroku access token', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  test.stdout()
+    .stderr()
+    .command(['borealis-pg:run', '-e', fakeShellCommand])
+    .catch(/^Missing required flag:/)
+    .it('exits with an error if there is no add-on name flag', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  test.stdout()
+    .stderr()
+    .command(['borealis-pg:run', '-o', fakeAddonName])
+    .catch(/^Missing required flag:/)
+    .it('exits with an error if there is no shell command flag', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  defaultTestContext
+    .do(() => when(mockSshClientFactoryType.create()).thenThrow(new Error('An error')))
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .catch('An error')
+    .it('throws an unexpected SSH client error when it occurs', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).never()
+    })
+
+  defaultTestContext
+    .command([
+      'borealis-pg:run',
+      '-o',
+      fakeAddonName,
+      '-p',
+      customPgPort.toString(),
+      '-e',
+      fakeShellCommand,
+    ])
+    .it('handles a local port conflict', ctx => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [_, listener] = capture(mockTcpServerType.on).last()
+      const errorListener = listener as ((err: unknown) => void)
+
+      errorListener({code: 'EADDRINUSE'})
+
+      expect(ctx.stderr).to.contain(`Local port ${customPgPort} is already in use`)
+      verify(mockNodeProcessType.exit(1)).once()
+    })
+
+  defaultTestContext
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .it('handles a generic proxy server error', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [_, listener] = capture(mockTcpServerType.on).last()
+      const errorListener = listener as ((err: unknown) => void)
+
+      const fakeError = new Error("This isn't a real error")
+      try {
+        errorListener(fakeError)
+
+        expect.fail('The error listener call should have thrown an error')
+      } catch (error) {
+        expect(error).to.equal(fakeError)
+      }
+    })
+
+  defaultTestContext
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .it('handles an error when starting port forwarding', () => {
+      const [tcpConnectionListener] = capture(mockTcpServerFactoryType.create).last()
+      tcpConnectionListener(mockTcpSocketInstance)
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [_, _1, _2, _3, portForwardListener] = capture(mockSshClientType.forwardOut).last()
+
+      const fakeError = new Error('Just testing!')
+      try {
+        portForwardListener(fakeError, mockSshStreamInstance)
+
+        expect.fail('The port forward listener call should have thrown an error')
+      } catch (error) {
+        expect(error).to.equal(fakeError)
+      }
+
+      verify(mockTcpSocketType.pipe(mockSshStreamInstance)).never()
+      verify(mockSshStreamType.pipe(mockTcpSocketInstance)).never()
+    })
+
+  defaultTestContext
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .it('handles an unexpected TCP socket error', () => {
+      const [tcpConnectionListener] = capture(mockTcpServerFactoryType.create).last()
+      tcpConnectionListener(mockTcpSocketInstance)
+
+      const expectedCallCount = 2
+      verify(mockTcpSocketType.on(anyString(), anyFunction())).times(expectedCallCount)
+      const socketListener = getTcpSocketListener('error', expectedCallCount)
+
+      const fakeError = new Error('Foobarbaz')
+      try {
+        socketListener(fakeError)
+
+        expect.fail('The socket error listener should have thrown an error')
+      } catch (error) {
+        expect(error).to.equal(fakeError)
+      }
+
+      verify(mockTcpSocketType.destroy()).never()
+    })
+
+  testContextWithAppConfigVars
+    .nock(herokuApiBaseUrl, api => api
+      .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+      .reply(200, [
+        {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
+      ]))
+    .nock(
+      borealisPgApiBaseUrl,
+      api => api.post(`/heroku/resources/${fakeAddonName}/personal-ssh-users`)
+        .reply(404, {reason: 'Add-on does not exist for a personal SSH user'}))
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .catch(`Add-on ${color.addon(fakeAddonName)} is not a Borealis Isolated Postgres add-on`)
+    .it('exits with an error if the add-on was not found', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).never()
+      verify(mockSshClientFactoryType.create()).never()
+    })
+
+  testContextWithAppConfigVars
+    .nock(herokuApiBaseUrl, api => api
+      .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+      .reply(200, [
+        {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
+      ]))
+    .nock(
+      borealisPgApiBaseUrl,
+      api => api.post(`/heroku/resources/${fakeAddonName}/personal-ssh-users`)
+        .reply(422, {reason: 'Add-on is not ready for a personal SSH user yet'}))
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .catch(`Add-on ${color.addon(fakeAddonName)} is not finished provisioning`)
+    .it('exits with an error if the add-on is still provisioning', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).never()
+      verify(mockSshClientFactoryType.create()).never()
+    })
+
+  testContextWithAppConfigVars
+    .nock(herokuApiBaseUrl, api => api
+      .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+      .reply(200, [
+        {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
+      ]))
+    .nock(
+      borealisPgApiBaseUrl,
+      api => api.post(`/heroku/resources/${fakeAddonName}/personal-ssh-users`)
+        .reply(503, {reason: 'Server error!'}))
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .catch('Add-on service is temporarily unavailable. Try again later.')
+    .it('exits with an error when there is an API error while creating the SSH user', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).never()
+      verify(mockSshClientFactoryType.create()).never()
+    })
+
+  baseTestContext
+    .nock(herokuApiBaseUrl, api => api
+      .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+      .reply(200, [
+        {
+          addon: {name: fakeAddonName},
+          app: {name: fakeHerokuAppName},
+          name: fakeAddonAttachmentName,
+        },
+      ])
+      .get(`/apps/${fakeHerokuAppName}/config-vars`)
+      .reply(500))
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.post(`/heroku/resources/${fakeAddonName}/personal-ssh-users`)
+        .reply(
+          200,
+          {
+            sshHost: fakeSshHost,
+            sshUsername: fakeSshUsername,
+            sshPrivateKey: fakeSshPrivateKey,
+            publicSshHostKey: expectedSshHostKeyEntry,
+          }))
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .catch('Add-on service is temporarily unavailable. Try again later.')
+    .it('exits with an error when there is an API error getting the app config vars', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).never()
+      verify(mockSshClientFactoryType.create()).never()
+    })
+
+  baseTestContext
+    .nock(herokuApiBaseUrl, api => api
+      .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+      .reply(200, [
+        {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
+      ]))
+    .nock(
+      borealisPgApiBaseUrl,
+      api => api.post(`/heroku/resources/${fakeAddonName}/personal-db-users`)
+        .reply(503, {reason: 'Server error!'})
+        .post(`/heroku/resources/${fakeAddonName}/personal-ssh-users`)
+        .reply(
+          200,
+          {
+            sshHost: fakeSshHost,
+            sshUsername: fakeSshUsername,
+            sshPrivateKey: fakeSshPrivateKey,
+            publicSshHostKey: expectedSshHostKeyEntry,
+          }))
+    .command(['borealis-pg:run', '-u', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .catch('Add-on service is temporarily unavailable. Try again later.')
+    .it('exits with an error when there is an API error while creating a personal DB user', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).never()
+      verify(mockSshClientFactoryType.create()).never()
+    })
+
+  baseTestContext
+    .nock(herokuApiBaseUrl, api => api
+      .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+      .reply(200, [
+        {
+          addon: {name: fakeAddonName},
+          app: {name: fakeHerokuAppName},
+          name: fakeAddonAttachmentName,
+        },
+      ])
+      .get(`/apps/${fakeHerokuAppName}/config-vars`)
+      .reply(200, {MY_COOL_DB_SSH_TUNNEL_BPG_CONNECTION_INFO: 'INVALID!'}))
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.post(`/heroku/resources/${fakeAddonName}/personal-ssh-users`)
+        .reply(
+          200,
+          {
+            sshHost: fakeSshHost,
+            sshUsername: fakeSshUsername,
+            sshPrivateKey: fakeSshPrivateKey,
+            publicSshHostKey: expectedSshHostKeyEntry,
+          }))
+    .command(['borealis-pg:run', '-o', fakeAddonName, '-e', fakeShellCommand])
+    .catch(
+      `The ${color.configVar('MY_COOL_DB_SSH_TUNNEL_BPG_CONNECTION_INFO')} config variable value ` +
+      `for ${color.app(fakeHerokuAppName)} is invalid. ` +
+      'This may indicate that the config variable was manually edited.')
+    .it('exits with an error when the app connection config var is invalid', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).never()
+      verify(mockSshClientFactoryType.create()).never()
+    })
+
+  function getTcpSocketListener(
+    expectedEventName: string,
+    expectedCallCount: number): (...args: unknown[]) => void {
+    for (let callIndex = 0; callIndex < expectedCallCount; callIndex++) {
+      const [eventName, socketListener] = capture(mockTcpSocketType.on).byCallIndex(callIndex)
+      if (eventName === expectedEventName) {
+        return socketListener
+      }
+    }
+
+    return expect.fail(`Could not find a TCP socket listener for the "${expectedEventName}" event`)
+  }
+
+  function executeSshClientListener(): void {
+    verify(mockSshClientType.on(anyString(), anyFunction())).once()
+    const [sshClientEvent, sshClientListener] = capture(mockSshClientType.on).last()
+    expect(sshClientEvent).to.equal('ready')
+
+    sshClientListener()
+  }
+})

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -1,0 +1,212 @@
+import color from '@heroku-cli/color'
+import {Command, flags} from '@heroku-cli/command'
+import {ConfigVars} from '@heroku-cli/schema'
+import {HTTP, HTTPError} from 'http-call'
+import {applyActionSpinner} from '../../async-actions'
+import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../borealis-api'
+import {
+  cliFlags,
+  consoleColours,
+  defaultPorts,
+  localPgHostname,
+  processAddonAttachmentInfo,
+} from '../../command-components'
+import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../heroku-api'
+import {DbConnectionInfo, openSshTunnel, SshConnectionInfo} from '../../ssh-tunneling'
+import tunnelServices from '../../tunnel-services'
+
+export default class RunCommand extends Command {
+  static description =
+    'runs a noninteractive command with a secure tunnel to a Borealis Isolated Postgres add-on\n' +
+    '\n' +
+    'The command is executed as the Heroku application database user by default, but\n' +
+    'it can be made to execute as a database user that is specifically tied to the\n' +
+    `current Heroku user via the ${consoleColours.cliFlagName('--personal-user')} flag instead. Note that any tables,\n` +
+    'indexes, views, etc. created when connected as a personal user will be owned by\n' +
+    'that user rather than the application database user unless ownership is\n' +
+    'explicitly reassigned.\n' +
+    '\n' +
+    'Shell commands are executed in a shell on the local machine with the following\n' +
+    'environment variables automatically set to allow connections over the secure\n' +
+    'tunnel to the remote add-on Postgres database:\n' +
+    `- ${consoleColours.envVar('PGHOST')}\n` +
+    `- ${consoleColours.envVar('PGPORT')}\n` +
+    `- ${consoleColours.envVar('PGDATABASE')}\n` +
+    `- ${consoleColours.envVar('PGUSER')}\n` +
+    `- ${consoleColours.envVar('PGPASSWORD')}\n` +
+    `- ${consoleColours.envVar('DATABASE_URL')}`
+
+  static flags = {
+    addon: cliFlags.addon,
+    app: cliFlags.app,
+    'personal-user': flags.boolean({
+      char: 'u',
+      description: 'run as a personal user rather than a user belonging to the Heroku application',
+      default: false,
+    }),
+    port: cliFlags.port,
+    'shell-command': flags.string({
+      char: 'e',
+      description: 'shell command to execute when the secure tunnel is established',
+      required: true,
+    }),
+    'write-access': cliFlags['write-access'],
+  }
+
+  async run() {
+    const {flags} = this.parse(RunCommand)
+    const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
+    const addonInfo = processAddonAttachmentInfo(
+      attachmentInfos,
+      {addonOrAttachment: flags.addon, app: flags.app},
+      this.error)
+
+    const [sshConnInfo, dbConnInfo] =
+      await this.prepareUsers(addonInfo, flags['personal-user'], flags['write-access'])
+
+    this.executeShellCommand(
+      sshConnInfo,
+      dbConnInfo,
+      flags.port,
+      flags['shell-command'])
+  }
+
+  private async prepareUsers(
+    addonInfo: {addonName: string; appName: string; attachmentName: string},
+    usePersonalUser: boolean,
+    enableWriteAccess: boolean): Promise<any[]> {
+    const authorization = await createHerokuAuth(this.heroku, true)
+    try {
+      const dbConnInfoPromise = !usePersonalUser ?
+        this.fetchAppDbConnInfo(addonInfo.appName, addonInfo.attachmentName, enableWriteAccess) :
+        HTTP
+          .post<DbConnectionInfo>(
+            getBorealisPgApiUrl(`/heroku/resources/${addonInfo.addonName}/personal-db-users`),
+            {
+              headers: {Authorization: getBorealisPgAuthHeader(authorization)},
+              body: {enableWriteAccess},
+            })
+          .then(value => value.body)
+
+      const [sshConnInfoResult, dbConnInfoResult] = await applyActionSpinner(
+        `Configuring user session for add-on ${color.addon(addonInfo.addonName)}`,
+        Promise.allSettled([
+          HTTP
+            .post<SshConnectionInfo>(
+              getBorealisPgApiUrl(`/heroku/resources/${addonInfo.addonName}/personal-ssh-users`),
+              {headers: {Authorization: getBorealisPgAuthHeader(authorization)}})
+            .then(value => value.body),
+          dbConnInfoPromise,
+        ]),
+      )
+
+      if (sshConnInfoResult.status === 'rejected') {
+        throw sshConnInfoResult.reason
+      } else if (dbConnInfoResult.status === 'rejected') {
+        throw dbConnInfoResult.reason
+      }
+
+      return [sshConnInfoResult.value, dbConnInfoResult.value]
+    } finally {
+      await removeHerokuAuth(this.heroku, authorization.id as string)
+    }
+  }
+
+  private async fetchAppDbConnInfo(
+    appName: string,
+    attachmentName: string,
+    enableWriteAccess: boolean): Promise<DbConnectionInfo> {
+    const appConnInfoConfigVarName = `${attachmentName}_SSH_TUNNEL_BPG_CONNECTION_INFO`
+    const configVarsInfo = await this.heroku.get<ConfigVars>(`/apps/${appName}/config-vars`)
+    const appConnInfo = configVarsInfo.body[appConnInfoConfigVarName]
+
+    const dbHostVar = enableWriteAccess ? 'POSTGRES_WRITER_HOST' : 'POSTGRES_READER_HOST'
+    const dbHostPattern = new RegExp(`${dbHostVar}:=([^|]+)`)
+    const dbHostMatch = appConnInfo.match(dbHostPattern)
+
+    const dbPortPattern = /POSTGRES_PORT:=(\d+)/
+    const dbPortMatch = appConnInfo.match(dbPortPattern)
+    const dbPort = dbPortMatch ? Number.parseInt(dbPortMatch[1], 10) : defaultPorts.pg
+
+    const dbNamePattern = /POSTGRES_DB_NAME:=([^|]+)/
+    const dbNameMatch = appConnInfo.match(dbNamePattern)
+
+    const dbUsernameVar =
+      enableWriteAccess ? 'POSTGRES_WRITER_USERNAME' : 'POSTGRES_READER_USERNAME'
+    const dbUsernamePattern = new RegExp(`${dbUsernameVar}:=([^|]+)`)
+    const dbUsernameMatch = appConnInfo.match(dbUsernamePattern)
+
+    const dbPasswordVar =
+      enableWriteAccess ? 'POSTGRES_WRITER_PASSWORD' : 'POSTGRES_READER_PASSWORD'
+    const dbPasswordPattern = new RegExp(`${dbPasswordVar}:=([^|]+)`)
+    const dbPasswordMatch = appConnInfo.match(dbPasswordPattern)
+
+    if (dbHostMatch && dbNameMatch && dbUsernameMatch && dbPasswordMatch) {
+      return {
+        dbHost: dbHostMatch[1],
+        dbPort,
+        dbName: dbNameMatch[1],
+        dbUsername: dbUsernameMatch[1],
+        dbPassword: dbPasswordMatch[1],
+      }
+    } else {
+      this.error(
+        `The ${color.configVar(appConnInfoConfigVarName)} config variable value for ` +
+        `${color.app(appName)} is invalid. ` +
+        'This may indicate that the config variable was manually edited.')
+    }
+  }
+
+  private executeShellCommand(
+    sshConnInfo: SshConnectionInfo,
+    dbConnInfo: DbConnectionInfo,
+    localPgPort: number,
+    shellCommand: string): void {
+    openSshTunnel(
+      {ssh: sshConnInfo, db: dbConnInfo, localPgPort: localPgPort},
+      {debug: this.debug, info: this.log, warn: this.warn, error: this.error},
+      sshClient => {
+        const commandProc = tunnelServices.childProcessFactory.spawn(shellCommand, {
+          env: {
+            ...tunnelServices.nodeProcess.env,
+            PGHOST: localPgHostname,
+            PGPORT: localPgPort.toString(),
+            PGDATABASE: dbConnInfo.dbName,
+            PGUSER: dbConnInfo.dbUsername,
+            PGPASSWORD: dbConnInfo.dbPassword,
+            DATABASE_URL:
+              `postgres://${dbConnInfo.dbUsername}:${dbConnInfo.dbPassword}@` +
+              `${localPgHostname}:${localPgPort}/${dbConnInfo.dbName}`,
+          },
+          shell: true,
+          stdio: ['ignore', null, null], // Disable stdin but use the defaults for stdout and stderr
+        }).on('exit', (code, _) => {
+          sshClient.end()
+          tunnelServices.nodeProcess.exit(code ?? undefined)
+        })
+
+        if (commandProc.stdout) {
+          commandProc.stdout.on('data', data => this.log(data.toString()))
+        }
+        if (commandProc.stderr) {
+          commandProc.stderr.on('data', data => this.error(data.toString(), {exit: false}))
+        }
+      })
+  }
+
+  async catch(err: any) {
+    const {flags} = this.parse(RunCommand)
+
+    if (err instanceof HTTPError) {
+      if (err.statusCode === 404) {
+        this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
+      } else if (err.statusCode === 422) {
+        this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)
+      } else {
+        this.error('Add-on service is temporarily unavailable. Try again later.')
+      }
+    } else {
+      throw err
+    }
+  }
+}

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -37,8 +37,10 @@ export default class TunnelCommand extends Command {
   async run() {
     const {flags} = this.parse(TunnelCommand)
     const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const addonName =
-      processAddonAttachmentInfo(this.error, attachmentInfos, flags.addon, flags.app)
+    const {addonName} = processAddonAttachmentInfo(
+      attachmentInfos,
+      {addonOrAttachment: flags.addon, app: flags.app},
+      this.error)
 
     const [sshConnInfo, dbConnInfo] =
       await this.createPersonalUsers(addonName, flags['write-access'])

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -1,17 +1,12 @@
 import color from '@heroku-cli/color'
 import {Command} from '@heroku-cli/command'
 import {HTTP, HTTPError} from 'http-call'
-import {Server} from 'net'
 import {Client as SshClient} from 'ssh2'
 import {applyActionSpinner} from '../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../borealis-api'
-import {
-  cliFlags,
-  defaultPorts,
-  localPgHostname,
-  processAddonAttachmentInfo,
-} from '../../command-components'
+import {cliFlags, localPgHostname, processAddonAttachmentInfo} from '../../command-components'
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../heroku-api'
+import {openSshTunnel} from '../../ssh-tunneling'
 import tunnelServices from '../../tunnel-services'
 
 const keyboardKeyColour = color.italic
@@ -45,7 +40,7 @@ export default class TunnelCommand extends Command {
     const [sshConnInfo, dbConnInfo] =
       await this.createPersonalUsers(addonName, flags['write-access'])
 
-    const sshClient = this.openSshTunnel(sshConnInfo, dbConnInfo, flags.port)
+    const sshClient = this.connect(sshConnInfo, dbConnInfo, flags.port)
 
     tunnelServices.nodeProcess.on('SIGINT', _ => {
       sshClient.end()
@@ -85,110 +80,38 @@ export default class TunnelCommand extends Command {
     }
   }
 
-  private openSshTunnel(
-    sshConnInfo: SshConnectionInfo,
-    dbConnInfo: DbConnectionInfo,
-    localPgPort: number): SshClient {
-    const sshClient = tunnelServices.sshClientFactory.create()
-
-    this.initProxyServer(dbConnInfo, localPgPort, sshClient)
-
-    return this.initSshClient(sshClient, sshConnInfo, dbConnInfo, localPgPort)
-  }
-
-  private initProxyServer(
-    dbConnInfo: DbConnectionInfo,
-    localPgPort: number,
-    sshClient: SshClient,
-  ): Server {
-    return tunnelServices.tcpServerFactory.create(tcpSocket => {
-      tcpSocket.on('end', () => {
-        this.debug(`Ended session on port ${tcpSocket.remotePort}`)
-      }).on('error', (socketErr: any) => {
-        if (socketErr.code === 'ECONNRESET') {
-          this.debug(`Server connection reset on port ${tcpSocket.remotePort}: ${socketErr}`)
-          tcpSocket.destroy()
-        } else {
-          this.error(socketErr)
-        }
-      })
-
-      sshClient.forwardOut(
-        localPgHostname,
-        localPgPort,
-        dbConnInfo.dbHost,
-        dbConnInfo.dbPort ?? defaultPorts.pg,
-        (sshErr, sshStream) => {
-          if (sshErr) {
-            this.error(sshErr)
-          }
-
-          this.debug(`Started session on port ${tcpSocket.remotePort}`)
-
-          tcpSocket.pipe(sshStream)
-          sshStream.pipe(tcpSocket)
-        })
-    }).on('error', (err: any) => {
-      if (err.code === 'EADDRINUSE') {
-        this.debug(err)
-
-        this.error(
-          `Local port ${localPgPort} is already in use. Specify a different port number with the --port flag.`,
-          {exit: false})
-        tunnelServices.nodeProcess.exit(1)
-      } else {
-        this.error(err)
-      }
-    }).listen(localPgPort, localPgHostname)
-  }
-
-  private initSshClient(
-    sshClient: SshClient,
+  private connect(
     sshConnInfo: SshConnectionInfo,
     dbConnInfo: DbConnectionInfo,
     localPgPort: number): SshClient {
     const dbUrl =
       `postgres://${dbConnInfo.dbUsername}:${dbConnInfo.dbPassword}` +
       `@${localPgHostname}:${localPgPort}/${dbConnInfo.dbName}`
-    const [expectedPublicSshHostKeyFormat, expectedPublicSshHostKey] =
-      sshConnInfo.publicSshHostKey.split(' ')
 
-    sshClient.on('ready', () => {
-      this.log()
-      this.log(
-        'Secure tunnel established. ' +
-        'Use the following values to connect to the database while the tunnel remains open:')
+    return openSshTunnel(
+      {ssh: sshConnInfo, db: dbConnInfo, localPgPort: localPgPort},
+      {debug: this.debug, info: this.log, warn: this.warn, error: this.error},
+      _ => {
+        this.log()
+        this.log(
+          'Secure tunnel established. ' +
+          'Use the following values to connect to the database while the tunnel remains open:')
 
-      // It was tempting to use cli.table for this, but it has the unfortunate side effect of
-      // cutting off long values such that they are impossible to recover
-      this.log(`      ${connKeyColour('Username')}: ${connValueColour(dbConnInfo.dbUsername)}`)
-      this.log(`      ${connKeyColour('Password')}: ${connValueColour(dbConnInfo.dbPassword)}`)
-      this.log(`          ${connKeyColour('Host')}: ${connValueColour(localPgHostname)}`)
-      this.log(`          ${connKeyColour('Port')}: ${connValueColour(localPgPort.toString())}`)
-      this.log(` ${connKeyColour('Database name')}: ${connValueColour(dbConnInfo.dbName)}`)
-      this.log(`           ${connKeyColour('URL')}: ${connValueColour(dbUrl)}`)
+        // It was tempting to use cli.table for this, but it has the unfortunate side effect of
+        // cutting off long values such that they are impossible to recover
+        this.log(`      ${connKeyColour('Username')}: ${connValueColour(dbConnInfo.dbUsername)}`)
+        this.log(`      ${connKeyColour('Password')}: ${connValueColour(dbConnInfo.dbPassword)}`)
+        this.log(`          ${connKeyColour('Host')}: ${connValueColour(localPgHostname)}`)
+        this.log(`          ${connKeyColour('Port')}: ${connValueColour(localPgPort.toString())}`)
+        this.log(` ${connKeyColour('Database name')}: ${connValueColour(dbConnInfo.dbName)}`)
+        this.log(`           ${connKeyColour('URL')}: ${connValueColour(dbUrl)}`)
 
-      this.log()
-      this.log(
-        `Press ${keyboardKeyColour('Ctrl')}+${keyboardKeyColour('C')} to close the tunnel and exit`)
-    }).connect({
-      host: sshConnInfo.sshHost,
-      port: sshConnInfo.sshPort ?? defaultPorts.ssh,
-      username: sshConnInfo.sshUsername,
-      privateKey: sshConnInfo.sshPrivateKey,
-      algorithms: {serverHostKey: [expectedPublicSshHostKeyFormat]},
-      hostVerifier: (keyHash: any) => {
-        const keyHashStr =
-          (keyHash instanceof Buffer) ? keyHash.toString('base64') : keyHash.toString()
-
-        this.debug(`Actual SSH host key: ${keyHashStr}`)
-        this.debug(`Expected SSH host key: ${expectedPublicSshHostKey}`)
-
-        return keyHashStr === expectedPublicSshHostKey
+        this.log()
+        this.log(
+          `Press ${keyboardKeyColour('Ctrl')}+${keyboardKeyColour('C')} ` +
+          'to close the tunnel and exit')
       },
-    })
-
-    return sshClient
+    )
   }
 
   async catch(err: any) {

--- a/src/ssh-tunneling.test.ts
+++ b/src/ssh-tunneling.test.ts
@@ -1,0 +1,403 @@
+import {Server, Socket} from 'net'
+import {Client as SshClient, ClientChannel} from 'ssh2'
+import {
+  anyFunction,
+  anyNumber,
+  anyString,
+  anything,
+  capture,
+  deepEqual,
+  instance,
+  mock,
+  verify,
+  when,
+} from 'ts-mockito'
+import {openSshTunnel} from './ssh-tunneling'
+import {expect} from './test-utils'
+import tunnelServices from './tunnel-services'
+
+const localPgHostname = 'localhost'
+const defaultSshPort = 22
+const customSshPort = 51022
+const defaultPgPort = 5432
+const customPgPort = 55432
+
+const fakeSshHost = 'my-fake-ssh-hostname'
+const fakeSshUsername = 'ssh-test-user'
+const fakeSshPrivateKey = 'my-fake-ssh-private-key'
+const fakePgHost = 'my-fake-pg-hostname'
+const fakePgReadWriteUsername = 'rw_db_test_user'
+const fakePgPassword = 'my-fake-db-password'
+const fakePgDbName = 'fake_db'
+
+const expectedSshHostKeyFormat = 'ssh-ed25519'
+const expectedSshHostKey = 'AAAAC3NzaC1lZDI1NTE5AAAAIKkk9uh8+g/gKlLlbi4sVv4VJkiaLjYOJj+wVVyTGzhI'
+const expectedSshHostKeyEntry = `${expectedSshHostKeyFormat} ${expectedSshHostKey}`
+
+const fakeCompleteConnInfo = {
+  db: {
+    dbHost: fakePgHost,
+    dbPort: customPgPort,
+    dbName: fakePgDbName,
+    dbUsername: fakePgReadWriteUsername,
+    dbPassword: fakePgPassword,
+  },
+  ssh: {
+    sshHost: fakeSshHost,
+    sshPort: customSshPort,
+    sshUsername: fakeSshUsername,
+    sshPrivateKey: fakeSshPrivateKey,
+    publicSshHostKey: expectedSshHostKeyEntry,
+  },
+  localPgPort: customPgPort,
+}
+
+const fakeNoPortsConnInfo = {
+  db: {
+    dbHost: fakePgHost,
+    dbName: fakePgDbName,
+    dbUsername: fakePgReadWriteUsername,
+    dbPassword: fakePgPassword,
+  },
+  ssh: {
+    sshHost: fakeSshHost,
+    sshUsername: fakeSshUsername,
+    sshPrivateKey: fakeSshPrivateKey,
+    publicSshHostKey: expectedSshHostKeyEntry,
+  },
+  localPgPort: defaultPgPort,
+}
+
+describe('openSshTunnel', () => {
+  let originalNodeProcess: NodeJS.Process
+  let originalTcpServerFactory: typeof tunnelServices.tcpServerFactory
+  let originalSshClientFactory: typeof tunnelServices.sshClientFactory
+
+  let mockNodeProcessType: NodeJS.Process
+
+  let mockTcpServerFactoryType: typeof tunnelServices.tcpServerFactory
+  let mockTcpServerType: Server
+
+  let mockSshClientFactoryType: typeof tunnelServices.sshClientFactory
+  let mockSshClientType: SshClient
+  let mockSshClientInstance: typeof mockSshClientType
+
+  let mockTcpSocketType: Socket
+  let mockTcpSocketInstance: typeof mockTcpSocketType
+
+  let mockSshStreamType: ClientChannel
+  let mockSshStreamInstance: typeof mockSshStreamType
+
+  let mockLoggerType: {
+    debug: (...args: any[]) => void;
+    info: (...args: any[]) => void;
+    warn: (...args: any[]) => void;
+    error: (...args: any[]) => void;
+  }
+  let mockLoggerInstance: typeof mockLoggerType
+
+  let mockReadyListenerContainerType: {func: (sshClient: SshClient) => void}
+  let mockReadyListenerContainerInstance: typeof mockReadyListenerContainerType
+
+  beforeEach(() => {
+    originalNodeProcess = tunnelServices.nodeProcess
+    originalTcpServerFactory = tunnelServices.tcpServerFactory
+    originalSshClientFactory = tunnelServices.sshClientFactory
+
+    mockNodeProcessType = mock()
+    tunnelServices.nodeProcess = instance(mockNodeProcessType)
+
+    mockTcpServerType = mock(Server)
+    const mockTcpServerInstance = instance(mockTcpServerType)
+    when(mockTcpServerType.on(anyString(), anyFunction())).thenReturn(mockTcpServerInstance)
+    when(mockTcpServerType.listen(anyNumber(), anyString())).thenReturn(mockTcpServerInstance)
+    when(mockTcpServerType.close()).thenReturn(mockTcpServerInstance)
+
+    mockTcpServerFactoryType = mock()
+    when(mockTcpServerFactoryType.create(anyFunction())).thenReturn(mockTcpServerInstance)
+    tunnelServices.tcpServerFactory = instance(mockTcpServerFactoryType)
+
+    mockSshClientType = mock(SshClient)
+    mockSshClientInstance = instance(mockSshClientType)
+    when(mockSshClientType.on(anyString(), anyFunction())).thenReturn(mockSshClientInstance)
+
+    mockSshClientFactoryType = mock()
+    when(mockSshClientFactoryType.create()).thenReturn(mockSshClientInstance)
+    tunnelServices.sshClientFactory = instance(mockSshClientFactoryType)
+
+    mockTcpSocketType = mock(Socket)
+    mockTcpSocketInstance = instance(mockTcpSocketType)
+    when(mockTcpSocketType.on(anyString(), anyFunction())).thenReturn(mockTcpSocketInstance)
+    when(mockTcpSocketType.pipe(anything())).thenReturn(mockTcpSocketInstance)
+
+    mockSshStreamType = mock()
+    mockSshStreamInstance = instance(mockSshStreamType)
+    when(mockSshStreamType.on(anyString(), anyFunction())).thenReturn(mockSshStreamInstance)
+    when(mockSshStreamType.pipe(anything())).thenReturn(mockSshStreamInstance)
+
+    mockLoggerType = mock()
+    // Throw an exception if the error function is called with only one argument
+    when(mockLoggerType.error(anything())).thenThrow(new Error('Error logged'))
+    mockLoggerInstance = instance(mockLoggerType)
+
+    mockReadyListenerContainerType = mock()
+    mockReadyListenerContainerInstance = instance(mockReadyListenerContainerType)
+  })
+
+  afterEach(() => {
+    tunnelServices.nodeProcess = originalNodeProcess
+    tunnelServices.sshClientFactory = originalSshClientFactory
+    tunnelServices.tcpServerFactory = originalTcpServerFactory
+  })
+
+  it('starts the proxy server', () => {
+    openSshTunnel(fakeCompleteConnInfo, mockLoggerInstance, _ => true)
+
+    verify(mockTcpServerFactoryType.create(anyFunction())).once()
+    verify(mockTcpServerType.on(anyString(), anyFunction())).once()
+    verify(mockTcpServerType.on('error', anyFunction())).once()
+    verify(mockTcpServerType.listen(anyNumber(), anyString())).once()
+    verify(mockTcpServerType.listen(customPgPort, localPgHostname)).once()
+  })
+
+  it('connects to the SSH server with an explicit SSH port in the connection info', () => {
+    openSshTunnel(fakeCompleteConnInfo, mockLoggerInstance, _ => true)
+
+    verify(mockSshClientFactoryType.create()).once()
+    verify(mockSshClientType.on(anyString(), anyFunction())).once()
+    verify(mockSshClientType.on('ready', anyFunction())).once()
+
+    verify(mockSshClientType.connect(anything())).once()
+    const [connectConfig] = capture(mockSshClientType.connect).last()
+    expect(connectConfig.host).to.equal(fakeSshHost)
+    expect(connectConfig.port).to.equal(customSshPort)
+    expect(connectConfig.username).to.equal(fakeSshUsername)
+    expect(connectConfig.privateKey).to.equal(fakeSshPrivateKey)
+    expect(connectConfig.algorithms).to.deep.equal({serverHostKey: [expectedSshHostKeyFormat]})
+
+    expect(connectConfig.hostVerifier).to.exist
+    const hostVerifier = connectConfig.hostVerifier as ((keyHash: unknown) => boolean)
+    expect(hostVerifier(expectedSshHostKey)).to.be.true
+    expect(hostVerifier('no good!')).to.be.false
+  })
+
+  it('connects to the SSH server without an SSH port in the connection info', () => {
+    openSshTunnel(fakeNoPortsConnInfo, mockLoggerInstance, _ => true)
+
+    verify(mockSshClientFactoryType.create()).once()
+    verify(mockSshClientType.on(anyString(), anyFunction())).once()
+    verify(mockSshClientType.on('ready', anyFunction())).once()
+
+    verify(mockSshClientType.connect(anything())).once()
+    const [connectConfig] = capture(mockSshClientType.connect).last()
+    expect(connectConfig.host).to.equal(fakeSshHost)
+    expect(connectConfig.port).to.equal(defaultSshPort)
+    expect(connectConfig.username).to.equal(fakeSshUsername)
+    expect(connectConfig.privateKey).to.equal(fakeSshPrivateKey)
+    expect(connectConfig.algorithms).to.deep.equal({serverHostKey: [expectedSshHostKeyFormat]})
+
+    expect(connectConfig.hostVerifier).to.exist
+    const hostVerifier = connectConfig.hostVerifier as ((keyHash: unknown) => boolean)
+    expect(hostVerifier(Buffer.from(expectedSshHostKey, 'base64'))).to.be.true
+    expect(hostVerifier(Buffer.from('no good!', 'base64'))).to.be.false
+  })
+
+  it('attaches the ready listener', () => {
+    const result = openSshTunnel(
+      fakeNoPortsConnInfo,
+      mockLoggerInstance,
+      mockReadyListenerContainerInstance.func)
+
+    expect(result).to.equal(mockSshClientInstance)
+
+    verify(mockSshClientType.on(anyString(), anyFunction())).once()
+    const [event, listener] = capture(mockSshClientType.on).last()
+    expect(event).to.equal('ready')
+
+    listener()
+
+    verify(mockReadyListenerContainerType.func(result)).once()
+  })
+
+  it('starts SSH port forwarding with an explicit DB port in the connection info', () => {
+    openSshTunnel(fakeCompleteConnInfo, mockLoggerInstance, _ => true)
+
+    const [tcpConnectionListener] = capture(mockTcpServerFactoryType.create).last()
+    tcpConnectionListener(mockTcpSocketInstance)
+
+    verify(mockSshClientType.forwardOut(
+      localPgHostname,
+      customPgPort,
+      fakePgHost,
+      customPgPort,
+      anyFunction())).once()
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, _1, _2, _3, portForwardListener] = capture(mockSshClientType.forwardOut).last()
+    portForwardListener(undefined, mockSshStreamInstance)
+
+    verify(mockTcpSocketType.pipe(mockSshStreamInstance)).once()
+    verify(mockSshStreamType.pipe(mockTcpSocketInstance)).once()
+
+    verify(mockTcpSocketType.on(anyString(), anyFunction())).twice()
+    verify(mockTcpSocketType.on('end', anyFunction())).once()
+    verify(mockTcpSocketType.on('error', anyFunction())).once()
+  })
+
+  it('starts SSH port forwarding without a DB port in the connection info', () => {
+    openSshTunnel(fakeNoPortsConnInfo, mockLoggerInstance, _ => true)
+
+    const [tcpConnectionListener] = capture(mockTcpServerFactoryType.create).last()
+    tcpConnectionListener(mockTcpSocketInstance)
+
+    verify(mockSshClientType.forwardOut(
+      localPgHostname,
+      defaultPgPort,
+      fakePgHost,
+      defaultPgPort,
+      anyFunction())).once()
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, _1, _2, _3, portForwardListener] = capture(mockSshClientType.forwardOut).last()
+    portForwardListener(undefined, mockSshStreamInstance)
+
+    verify(mockTcpSocketType.pipe(mockSshStreamInstance)).once()
+    verify(mockSshStreamType.pipe(mockTcpSocketInstance)).once()
+
+    verify(mockTcpSocketType.on(anyString(), anyFunction())).twice()
+    verify(mockTcpSocketType.on('end', anyFunction())).once()
+    verify(mockTcpSocketType.on('error', anyFunction())).once()
+  })
+
+  it('throws an unexpected SSH client error when it occurs', () => {
+    when(mockSshClientFactoryType.create()).thenThrow(new Error('An error'))
+
+    expect(() => openSshTunnel(fakeNoPortsConnInfo, mockLoggerInstance, _ => true)).to.throw
+
+    verify(mockTcpServerFactoryType.create(anyFunction())).never()
+  })
+
+  it('handles a local port conflict', () => {
+    openSshTunnel(fakeCompleteConnInfo, mockLoggerInstance, _ => true)
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, listener] = capture(mockTcpServerType.on).last()
+    const errorListener = listener as ((err: unknown) => void)
+
+    errorListener({code: 'EADDRINUSE'})
+    verify(
+      mockLoggerType.error(
+        `Local port ${fakeCompleteConnInfo.localPgPort} is already in use. Specify a different port number with the --port flag.`,
+        deepEqual({exit: false})))
+      .once()
+    verify(mockNodeProcessType.exit(1)).once()
+  })
+
+  it('handles a generic proxy server error', () => {
+    openSshTunnel(fakeCompleteConnInfo, mockLoggerInstance, _ => true)
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, listener] = capture(mockTcpServerType.on).last()
+    const errorListener = listener as ((err: unknown) => void)
+
+    const fakeError = new Error("This isn't a real error")
+    try {
+      errorListener(fakeError)
+
+      expect.fail('The error listener call should have thrown an error')
+    } catch (error) {
+      verify(mockLoggerType.error(fakeError)).once()
+    }
+  })
+
+  it('handles an error when starting port forwarding', () => {
+    openSshTunnel(fakeCompleteConnInfo, mockLoggerInstance, _ => true)
+
+    const [tcpConnectionListener] = capture(mockTcpServerFactoryType.create).last()
+    tcpConnectionListener(mockTcpSocketInstance)
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, _1, _2, _3, portForwardListener] = capture(mockSshClientType.forwardOut).last()
+
+    const fakeError = new Error('Just testing!')
+    try {
+      portForwardListener(fakeError, mockSshStreamInstance)
+
+      expect.fail('The port forward listener call should have thrown an error')
+    } catch (error) {
+      verify(mockLoggerType.error(fakeError)).once()
+    }
+
+    verify(mockTcpSocketType.pipe(anything())).never()
+    verify(mockSshStreamType.pipe(anything())).never()
+  })
+
+  it('handles a server connection reset', () => {
+    openSshTunnel(fakeCompleteConnInfo, mockLoggerInstance, _ => true)
+
+    const [tcpConnectionListener] = capture(mockTcpServerFactoryType.create).last()
+    tcpConnectionListener(mockTcpSocketInstance)
+
+    const expectedCallCount = 2
+    verify(mockTcpSocketType.on(anyString(), anyFunction())).times(expectedCallCount)
+    const socketListener = getTcpSocketListener('error', expectedCallCount)
+
+    try {
+      socketListener({code: 'ECONNRESET'})
+    } catch (error) {
+      expect.fail('The socket error listener should not have thrown an error')
+    }
+
+    verify(mockTcpSocketType.destroy()).once()
+  })
+
+  it('handles an unexpected TCP socket error', () => {
+    openSshTunnel(fakeCompleteConnInfo, mockLoggerInstance, _ => true)
+
+    const [tcpConnectionListener] = capture(mockTcpServerFactoryType.create).last()
+    tcpConnectionListener(mockTcpSocketInstance)
+
+    const expectedCallCount = 2
+    verify(mockTcpSocketType.on(anyString(), anyFunction())).times(expectedCallCount)
+    const socketListener = getTcpSocketListener('error', expectedCallCount)
+
+    const fakeError = new Error('Foobarbaz')
+    try {
+      socketListener(fakeError)
+
+      expect.fail('The socket error listener should have thrown an error')
+    } catch (error) {
+      verify(mockLoggerType.error(fakeError)).once()
+    }
+
+    verify(mockTcpSocketType.destroy()).never()
+  })
+
+  it('handles a TCP socket being ended', () => {
+    openSshTunnel(fakeCompleteConnInfo, mockLoggerInstance, _ => true)
+
+    const [tcpConnectionListener] = capture(mockTcpServerFactoryType.create).last()
+    tcpConnectionListener(mockTcpSocketInstance)
+
+    const expectedCallCount = 2
+    verify(mockTcpSocketType.on(anyString(), anyFunction())).times(expectedCallCount)
+    const socketListener = getTcpSocketListener('end', expectedCallCount)
+
+    socketListener()
+
+    verify(mockTcpSocketType.remotePort).once()
+  })
+
+  function getTcpSocketListener(
+    expectedEventName: string,
+    expectedCallCount: number): (...args: unknown[]) => void {
+    for (let callIndex = 0; callIndex < expectedCallCount; callIndex++) {
+      const [eventName, socketListener] = capture(mockTcpSocketType.on).byCallIndex(callIndex)
+      if (eventName === expectedEventName) {
+        return socketListener
+      }
+    }
+
+    return expect.fail(`Could not find a TCP socket listener for the "${expectedEventName}" event`)
+  }
+})

--- a/src/ssh-tunneling.ts
+++ b/src/ssh-tunneling.ts
@@ -1,0 +1,129 @@
+import {Server} from 'net'
+import {Client as SshClient} from 'ssh2'
+import {defaultPorts, localPgHostname} from './command-components'
+import tunnelServices from './tunnel-services'
+
+/**
+ * Establishes an SSH tunnel for an add-on Postgres database
+ *
+ * @param connInfo The connection info
+ * @param logger Logging methods
+ * @param readyListener The callback to execute when the tunnel is established
+ *
+ * @returns The SSH client
+ */
+export function openSshTunnel(
+  connInfo: FullConnectionInfo,
+  logger: Logger,
+  readyListener: (sshClient: SshClient) => void): SshClient {
+  const sshClient = tunnelServices.sshClientFactory.create()
+
+  initProxyServer(sshClient, connInfo, logger)
+
+  return initSshClient(sshClient, connInfo, logger, () => readyListener(sshClient))
+}
+
+function initProxyServer(
+  sshClient: SshClient,
+  connInfo: FullConnectionInfo,
+  logger: Logger): Server {
+  return tunnelServices.tcpServerFactory.create(tcpSocket => {
+    tcpSocket.on('end', () => {
+      logger.debug(`Ended session on port ${tcpSocket.remotePort}`)
+    }).on('error', (socketErr: any) => {
+      if (socketErr.code === 'ECONNRESET') {
+        logger.debug(`Server connection reset on port ${tcpSocket.remotePort}: ${socketErr}`)
+        tcpSocket.destroy()
+      } else {
+        logger.error(socketErr)
+      }
+    })
+
+    sshClient.forwardOut(
+      localPgHostname,
+      connInfo.localPgPort,
+      connInfo.db.dbHost,
+      connInfo.db.dbPort ?? defaultPorts.pg,
+      (sshErr, sshStream) => {
+        if (sshErr) {
+          logger.error(sshErr)
+        }
+
+        logger.debug(`Started session on port ${tcpSocket.remotePort}`)
+
+        tcpSocket.pipe(sshStream)
+        sshStream.pipe(tcpSocket)
+      })
+  }).on('error', (err: any) => {
+    if (err.code === 'EADDRINUSE') {
+      logger.debug(err)
+
+      // Do not let the error function throw an exception or it will generate an ugly stack trace
+      logger.error(
+        `Local port ${connInfo.localPgPort} is already in use. Specify a different port number with the --port flag.`,
+        {exit: false})
+
+      tunnelServices.nodeProcess.exit(1)
+    } else {
+      logger.error(err)
+    }
+  }).listen(connInfo.localPgPort, localPgHostname)
+}
+
+function initSshClient(
+  sshClient: SshClient,
+  connInfo: {ssh: SshConnectionInfo; db: DbConnectionInfo; localPgPort: number},
+  logger: Logger,
+  onReady: () => void): SshClient {
+  const [expectedPublicSshHostKeyFormat, expectedPublicSshHostKey] =
+    connInfo.ssh.publicSshHostKey.split(' ')
+
+  sshClient.on('ready', onReady)
+    .connect({
+      host: connInfo.ssh.sshHost,
+      port: connInfo.ssh.sshPort ?? defaultPorts.ssh,
+      username: connInfo.ssh.sshUsername,
+      privateKey: connInfo.ssh.sshPrivateKey,
+      algorithms: {serverHostKey: [expectedPublicSshHostKeyFormat]},
+      hostVerifier: (keyHash: any) => {
+        const keyHashStr =
+          (keyHash instanceof Buffer) ? keyHash.toString('base64') : keyHash.toString()
+
+        logger.debug(`Actual SSH host key: ${keyHashStr}`)
+        logger.debug(`Expected SSH host key: ${expectedPublicSshHostKey}`)
+
+        return keyHashStr === expectedPublicSshHostKey
+      },
+    })
+
+  return sshClient
+}
+
+export interface SshConnectionInfo {
+  sshHost: string;
+  sshPort?: number;
+  sshUsername: string;
+  sshPrivateKey: string;
+  publicSshHostKey: string;
+}
+
+export interface DbConnectionInfo {
+  dbHost: string;
+  dbPort?: number;
+  dbName: string;
+  dbUsername: string;
+  dbPassword: string;
+}
+
+interface FullConnectionInfo {
+  db: DbConnectionInfo;
+  ssh: SshConnectionInfo;
+  localPgPort: number;
+}
+
+interface Logger {
+  debug: (...args: any[]) => void;
+  info: (message?: string | undefined, ...args: any[]) => void;
+  warn: (input: string | Error) => void;
+  error: (input: string | Error, options?: {[name: string]: any}) => never | void;
+}

--- a/src/tunnel-services.test.ts
+++ b/src/tunnel-services.test.ts
@@ -2,6 +2,19 @@ import {expect} from './test-utils'
 import tunnelServices from './tunnel-services'
 
 describe('tunnel services', () => {
+  it('should have a valid child process factory', () => {
+    let result = null
+    try {
+      result = tunnelServices.childProcessFactory.spawn('ls', {})
+
+      expect(result.pid).to.be.greaterThanOrEqual(0)
+    } finally {
+      if (result) {
+        result.kill()
+      }
+    }
+  })
+
   it('should reference the global Node.js process', () => {
     expect(tunnelServices.nodeProcess).to.equal(process)
   })

--- a/src/tunnel-services.ts
+++ b/src/tunnel-services.ts
@@ -1,3 +1,4 @@
+import childProcess, {SpawnOptions} from 'child_process'
 import {createServer, Socket} from 'net'
 import {Client as SshClient} from 'ssh2'
 
@@ -7,6 +8,9 @@ import {Client as SshClient} from 'ssh2'
  * Since oclif doesn't support dependency injection for commands, this is the next best thing.
  */
 export default {
+  childProcessFactory: {
+    spawn: (command: string, options: SpawnOptions) => childProcess.spawn(command, options),
+  },
   nodeProcess: process,
   sshClientFactory: {create: () => new SshClient()},
   tcpServerFactory: {


### PR DESCRIPTION
Adds the `borealis-pg:run` command to execute an arbitrary shell command with various environment variables set to enable access to an add-on's Postgres database. Most likely to be useful for executing database migrations scripts.