### PR TITLE
Execute noninteractive database commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
 ## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.1.0...HEAD)
-- `borealis-pg:run` command to execute a noninteractive shell command for an add-on database
+- `borealis-pg:run` command to execute a noninteractive SQL or shell command for an add-on database
 
 ## [0.1.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/477321d...v0.1.0) - 2021-09-24
 First public pre-release version

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@oclif/config": "^1.17.0",
     "cli-ux": "^5.6.3",
     "http-call": "^5.3.0",
+    "pg": "^8.7.1",
     "ssh2": "^1.4.0",
     "tslib": "^2.3.0"
   },
@@ -23,6 +24,7 @@
     "@types/chai-string": "^1.4.2",
     "@types/mocha": "^9.0.0",
     "@types/node": "^12.20.18",
+    "@types/pg": "^8.6.1",
     "@types/ssh2": "^0.5.47",
     "@types/supports-color": "^8.1.1",
     "chai": "^4.3.4",
@@ -87,7 +89,7 @@
     "lint": "eslint --max-warnings 0 --ext .ts --config .eslintrc .",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
-    "test": "nyc mocha --forbid-only \"**/*.test.ts\"",
+    "test": "nyc mocha --forbid-only \"src/**/*.test.ts\"",
     "version": "oclif-dev readme && git add README.md"
   }
 }

--- a/src/command-components.test.ts
+++ b/src/command-components.test.ts
@@ -2,7 +2,17 @@ import color from '@heroku-cli/color'
 import {AddOnAttachment} from '@heroku-cli/schema'
 import {expect} from 'fancy-test'
 import {anyString, instance, mock, verify} from 'ts-mockito'
-import {consoleColours, processAddonAttachmentInfo} from './command-components'
+import {consoleColours, formatCliFlagName, processAddonAttachmentInfo} from './command-components'
+
+describe('formatCliFlagName', () => {
+  it('returns a formatted CLI flag name', () => {
+    const flagName = 'my-fine-flag'
+
+    const result = formatCliFlagName(flagName)
+
+    expect(result).to.equal(consoleColours.cliFlag(`--${flagName}`))
+  })
+})
 
 describe('processAddonAttachmentInfo', () => {
   const fakeAddonAttachmentName = 'MY_NEAT_DB'
@@ -86,7 +96,7 @@ describe('processAddonAttachmentInfo', () => {
   it('indicates when the add-on name does not correspond to an add-on', () => {
     const expectedMessage =
       `Add-on ${color.addon(fakeAddonName)} was not found. Consider trying again with the ` +
-      `${consoleColours.cliFlagName('--app')} flag.`
+      `${consoleColours.cliFlag('--app')} flag.`
 
     const result = processAddonAttachmentInfo(
       null,

--- a/src/command-components.ts
+++ b/src/command-components.ts
@@ -3,7 +3,7 @@ import {flags} from '@heroku-cli/command'
 import {AddOnAttachment} from '@heroku-cli/schema'
 
 export const consoleColours = {
-  cliFlagName: color.bold.italic,
+  cliFlag: color.bold.italic,
   envVar: color.bold,
   pgExtension: color.green,
 }
@@ -44,11 +44,27 @@ export const cliFlags = {
       return value
     },
   }),
-  'write-access': flags.boolean({
+  writeAccess: flags.boolean({
     char: 'w',
     default: false,
     description: 'allow write access to the add-on Postgres database',
   }),
+}
+
+export const addonFlagName = 'addon'
+export const appFlagName = 'app'
+export const portFlagName = 'port'
+export const writeAccessFlagName = 'write-access'
+
+/**
+ * Formats the given CLI flag name for use in console output
+ *
+ * @param name The flag name
+ *
+ * @returns The formatted flag name
+ */
+export function formatCliFlagName(name: string): string {
+  return consoleColours.cliFlag(`--${name}`)
 }
 
 /**
@@ -86,6 +102,6 @@ export function processAddonAttachmentInfo(
   } else {
     return errorHandler(
       `Add-on ${color.addon(addonFilter.addonOrAttachment)} was not found. Consider trying again ` +
-      `with the ${consoleColours.cliFlagName('--app')} flag.`)
+      `with the ${formatCliFlagName(appFlagName)} flag.`)
   }
 }

--- a/src/commands/borealis-pg/extensions/index.ts
+++ b/src/commands/borealis-pg/extensions/index.ts
@@ -3,7 +3,13 @@ import {Command} from '@heroku-cli/command'
 import {HTTP, HTTPError} from 'http-call'
 import {applyActionSpinner} from '../../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../../borealis-api'
-import {cliFlags, consoleColours, processAddonAttachmentInfo} from '../../../command-components'
+import {
+  addonFlagName,
+  appFlagName,
+  cliFlags,
+  consoleColours,
+  processAddonAttachmentInfo,
+} from '../../../command-components'
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../../heroku-api'
 
 const pgExtensionColour = consoleColours.pgExtension
@@ -12,8 +18,8 @@ export default class ListPgExtensionsCommand extends Command {
   static description = 'lists installed Postgres extensions for a Borealis Isolated Postgres add-on'
 
   static flags = {
-    addon: cliFlags.addon,
-    app: cliFlags.app,
+    [addonFlagName]: cliFlags.addon,
+    [appFlagName]: cliFlags.app,
   }
 
   async run() {

--- a/src/commands/borealis-pg/extensions/install.ts
+++ b/src/commands/borealis-pg/extensions/install.ts
@@ -5,16 +5,20 @@ import {HTTP, HTTPError} from 'http-call'
 import {applyActionSpinner} from '../../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../../borealis-api'
 import {
+  addonFlagName,
+  appFlagName,
   cliArgs,
   cliFlags,
   consoleColours,
+  formatCliFlagName,
   processAddonAttachmentInfo,
 } from '../../../command-components'
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../../heroku-api'
 
-const cliFlagColour = consoleColours.cliFlagName
 const pgExtensionColour = consoleColours.pgExtension
 const dbSchemaColour = color.grey
+
+const recursiveFlagName = 'recursive'
 
 export default class InstallPgExtensionsCommand extends Command {
   static description =
@@ -33,9 +37,9 @@ export default class InstallPgExtensionsCommand extends Command {
   ]
 
   static flags = {
-    addon: cliFlags.addon,
-    app: cliFlags.app,
-    recursive: flags.boolean({
+    [addonFlagName]: cliFlags.addon,
+    [appFlagName]: cliFlags.app,
+    [recursiveFlagName]: flags.boolean({
       char: 'r',
       default: false,
       description: 'automatically install Postgres extension dependencies recursively',
@@ -143,7 +147,7 @@ export default class InstallPgExtensionsCommand extends Command {
           this.error(
             `Extension ${pgExtensionColour(pgExtension)} has one or more unsatisfied ` +
             `dependencies. All of its dependencies (${dependenciesString}) must be installed.\n` +
-            `Run this command again with the ${cliFlagColour('--recursive')} flag to ` +
+            `Run this command again with the ${formatCliFlagName(recursiveFlagName)} flag to ` +
             'automatically and recursively install the extension and the missing extension(s) it ' +
             'depends on.')
         } else {

--- a/src/commands/borealis-pg/extensions/remove.ts
+++ b/src/commands/borealis-pg/extensions/remove.ts
@@ -5,6 +5,8 @@ import {HTTP, HTTPError} from 'http-call'
 import {applyActionSpinner} from '../../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../../borealis-api'
 import {
+  addonFlagName,
+  appFlagName,
   cliArgs,
   cliFlags,
   consoleColours,
@@ -14,6 +16,8 @@ import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../.
 
 const pgExtensionColour = consoleColours.pgExtension
 
+const confirmFlagName = 'confirm'
+
 export default class RemovePgExtensionCommand extends Command {
   static description = 'removes a Postgres extension from a Borealis Isolated Postgres add-on'
 
@@ -22,9 +26,9 @@ export default class RemovePgExtensionCommand extends Command {
   ]
 
   static flags = {
-    addon: cliFlags.addon,
-    app: cliFlags.app,
-    confirm: flags.string({
+    [addonFlagName]: cliFlags.addon,
+    [appFlagName]: cliFlags.app,
+    [confirmFlagName]: flags.string({
       char: 'c',
       description: 'bypass the prompt for confirmation by specifying the name of the extension',
     }),

--- a/src/commands/borealis-pg/run.test.ts
+++ b/src/commands/borealis-pg/run.test.ts
@@ -839,8 +839,8 @@ describe('noninteractive run command', () => {
     .stderr()
     .command(['borealis-pg:run', '-o', fakeAddonName])
     .catch(
-      `Either ${consoleColours.cliFlagName('--db-command')} or ` +
-      `${consoleColours.cliFlagName('--shell-command')} must be specified`)
+      `Either ${consoleColours.cliFlag('--db-command')} or ` +
+      `${consoleColours.cliFlag('--shell-command')} must be specified`)
     .it('exits with an error if there is no shell command or database command flag', ctx => {
       expect(ctx.stdout).to.equal('')
     })

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -1,7 +1,9 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ConfigVars} from '@heroku-cli/schema'
+import {cli} from 'cli-ux'
 import {HTTP, HTTPError} from 'http-call'
+import {QueryResult} from 'pg'
 import {applyActionSpinner} from '../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../borealis-api'
 import {
@@ -12,29 +14,43 @@ import {
   processAddonAttachmentInfo,
 } from '../../command-components'
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../heroku-api'
-import {DbConnectionInfo, openSshTunnel, SshConnectionInfo} from '../../ssh-tunneling'
+import {
+  DbConnectionInfo,
+  FullConnectionInfo,
+  openSshTunnel,
+  SshConnectionInfo,
+} from '../../ssh-tunneling'
 import tunnelServices from '../../tunnel-services'
+
+const defaultOutputFormat = 'table'
 
 export default class RunCommand extends Command {
   static description =
-    'runs a noninteractive command with a secure tunnel to a Borealis Isolated Postgres add-on\n' +
-    '\n' +
-    'The command is executed as the Heroku application database user by default, but\n' +
-    'it can be made to execute as a database user that is specifically tied to the\n' +
-    `current Heroku user via the ${consoleColours.cliFlagName('--personal-user')} flag instead. Note that any tables,\n` +
-    'indexes, views, etc. created when connected as a personal user will be owned by\n' +
-    'that user rather than the application database user unless ownership is\n' +
-    'explicitly reassigned.\n' +
-    '\n' +
-    'Shell commands are executed in a shell on the local machine with the following\n' +
-    'environment variables automatically set to allow connections over the secure\n' +
-    'tunnel to the remote add-on Postgres database:\n' +
-    `- ${consoleColours.envVar('PGHOST')}\n` +
-    `- ${consoleColours.envVar('PGPORT')}\n` +
-    `- ${consoleColours.envVar('PGDATABASE')}\n` +
-    `- ${consoleColours.envVar('PGUSER')}\n` +
-    `- ${consoleColours.envVar('PGPASSWORD')}\n` +
-    `- ${consoleColours.envVar('DATABASE_URL')}`
+    `runs a noninteractive command with a secure tunnel to a Borealis Isolated Postgres add-on
+
+A command can take the form of a database command or a shell command. In either
+case, it is executed using the Heroku application's dedicated database user by
+default, but it can be made to execute as a database user that is specifically
+tied to the current Heroku user account via the ${consoleColours.cliFlagName('--personal-user')} flag instead.
+Note that any tables, indexes, views or other objects that are created when
+connected as a personal user will be owned by that user rather than the
+application database user unless ownership is explicitly reassigned.
+
+Database commands are raw statements (e.g. SQL, PL/pgSQL) that are sent over
+the secure tunnel to the add-on Postgres database to be executed verbatim with
+the results then written to the console on stdout.
+
+Shell commands are useful for executing an application's database migration
+scripts or other unattended database scripts. They are executed in a shell on
+the local machine with the following environment variables automatically set to
+allow scripts and applications that are launched by the command to connect over
+the secure tunnel to the remote add-on Postgres database:
+    - ${consoleColours.envVar('PGHOST')}
+    - ${consoleColours.envVar('PGPORT')}
+    - ${consoleColours.envVar('PGDATABASE')}
+    - ${consoleColours.envVar('PGUSER')}
+    - ${consoleColours.envVar('PGPASSWORD')}
+    - ${consoleColours.envVar('DATABASE_URL')}`
 
   static flags = {
     addon: cliFlags.addon,
@@ -44,61 +60,96 @@ export default class RunCommand extends Command {
       description: 'run as a personal user rather than a user belonging to the Heroku application',
       default: false,
     }),
+    'db-command': flags.string({
+      char: 'd',
+      description: 'database command to execute when the secure tunnel is established',
+      exclusive: ['shell-command'],
+    }),
+    format: flags.enum({
+      char: 'f',
+      dependsOn: ['db-command'],
+      description: `[default: ${defaultOutputFormat}] output format for database command results`,
+      exclusive: ['shell-command'],
+      options: [defaultOutputFormat, 'csv', 'json', 'yaml'],
+    }),
     port: cliFlags.port,
     'shell-command': flags.string({
       char: 'e',
       description: 'shell command to execute when the secure tunnel is established',
-      required: true,
+      exclusive: ['db-command', 'format'],
     }),
     'write-access': cliFlags['write-access'],
   }
 
   async run() {
     const {flags} = this.parse(RunCommand)
+    const dbCommand = flags['db-command']
+    const shellCommand = flags['shell-command']
+
+    if ((typeof dbCommand === 'undefined') && (typeof shellCommand === 'undefined')) {
+      this.error(
+        `Either ${consoleColours.cliFlagName('--db-command')} or ` +
+        `${consoleColours.cliFlagName('--shell-command')} must be specified`)
+    }
+
+    const normalizedOutputFormat =
+      (flags.format === defaultOutputFormat) ? undefined : flags.format
+
     const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
     const addonInfo = processAddonAttachmentInfo(
       attachmentInfos,
       {addonOrAttachment: flags.addon, app: flags.app},
       this.error)
 
-    const [sshConnInfo, dbConnInfo] =
-      await this.prepareUsers(addonInfo, flags['personal-user'], flags['write-access'])
+    const [sshConnInfo, dbConnInfo] = await this.prepareUsers(
+      addonInfo,
+      flags['personal-user'],
+      flags['write-access'],
+      typeof normalizedOutputFormat === 'undefined')
+    const fullConnInfo = {ssh: sshConnInfo, db: dbConnInfo, localPgPort: flags.port}
 
-    this.executeShellCommand(
-      sshConnInfo,
-      dbConnInfo,
-      flags.port,
-      flags['shell-command'])
+    if (dbCommand) {
+      this.executeDbCommand(fullConnInfo, dbCommand, normalizedOutputFormat)
+    } else {
+      this.executeShellCommand(fullConnInfo, shellCommand as string)
+    }
   }
 
   private async prepareUsers(
     addonInfo: {addonName: string; appName: string; attachmentName: string},
     usePersonalUser: boolean,
-    enableWriteAccess: boolean): Promise<any[]> {
+    enableWriteAccess: boolean,
+    showSpinner: boolean): Promise<any[]> {
     const authorization = await createHerokuAuth(this.heroku, true)
     try {
-      const dbConnInfoPromise = !usePersonalUser ?
-        this.fetchAppDbConnInfo(addonInfo.appName, addonInfo.attachmentName, enableWriteAccess) :
-        HTTP
-          .post<DbConnectionInfo>(
-            getBorealisPgApiUrl(`/heroku/resources/${addonInfo.addonName}/personal-db-users`),
-            {
-              headers: {Authorization: getBorealisPgAuthHeader(authorization)},
-              body: {enableWriteAccess},
-            })
-          .then(value => value.body)
-
-      const [sshConnInfoResult, dbConnInfoResult] = await applyActionSpinner(
-        `Configuring user session for add-on ${color.addon(addonInfo.addonName)}`,
-        Promise.allSettled([
+      const dbConnInfoPromise =
+        !usePersonalUser ?
+          this.fetchAppDbConnInfo(addonInfo.appName, addonInfo.attachmentName, enableWriteAccess) :
           HTTP
-            .post<SshConnectionInfo>(
-              getBorealisPgApiUrl(`/heroku/resources/${addonInfo.addonName}/personal-ssh-users`),
-              {headers: {Authorization: getBorealisPgAuthHeader(authorization)}})
-            .then(value => value.body),
-          dbConnInfoPromise,
-        ]),
-      )
+            .post<DbConnectionInfo>(
+              getBorealisPgApiUrl(`/heroku/resources/${addonInfo.addonName}/personal-db-users`),
+              {
+                headers: {Authorization: getBorealisPgAuthHeader(authorization)},
+                body: {enableWriteAccess},
+              })
+            .then(value => value.body)
+
+      const fullConnInfoPromise = Promise.allSettled([
+        HTTP
+          .post<SshConnectionInfo>(
+            getBorealisPgApiUrl(`/heroku/resources/${addonInfo.addonName}/personal-ssh-users`),
+            {headers: {Authorization: getBorealisPgAuthHeader(authorization)}})
+          .then(value => value.body),
+        dbConnInfoPromise,
+      ])
+
+      const [sshConnInfoResult, dbConnInfoResult] =
+        !showSpinner ?
+          await fullConnInfoPromise :
+          await applyActionSpinner(
+            `Configuring user session for add-on ${color.addon(addonInfo.addonName)}`,
+            fullConnInfoPromise,
+          )
 
       if (sshConnInfoResult.status === 'rejected') {
         throw sshConnInfoResult.reason
@@ -157,26 +208,86 @@ export default class RunCommand extends Command {
     }
   }
 
-  private executeShellCommand(
-    sshConnInfo: SshConnectionInfo,
-    dbConnInfo: DbConnectionInfo,
-    localPgPort: number,
-    shellCommand: string): void {
+  private executeDbCommand(
+    connInfo: FullConnectionInfo,
+    dbCommand: string,
+    outputFormat?: string): void {
     openSshTunnel(
-      {ssh: sshConnInfo, db: dbConnInfo, localPgPort: localPgPort},
+      connInfo,
+      {debug: this.debug, info: this.log, warn: this.warn, error: this.error},
+      sshClient => {
+        const pgClient = tunnelServices.pgClientFactory.create({
+          host: localPgHostname,
+          port: connInfo.localPgPort,
+          database: connInfo.db.dbName,
+          user: connInfo.db.dbUsername,
+          password: connInfo.db.dbPassword,
+        }).on('end', () => {
+          sshClient.end()
+          tunnelServices.nodeProcess.exit()
+        }).on('error', (err: Error) => {
+          // Do not let the error function exit or it will generate an ugly stack trace
+          this.error(err, {exit: false})
+          tunnelServices.nodeProcess.exit(1)
+        })
+
+        pgClient.connect()
+
+        pgClient.query(
+          dbCommand,
+          (err: Error | null | undefined, results: QueryResult<any> | QueryResult<any>[]) => {
+            if (err) {
+              // Do not let the error function exit or it will generate an ugly stack trace
+              this.error(err, {exit: false})
+              tunnelServices.nodeProcess.exit(1)
+            } else {
+              // When multiple statements are executed, the query result will be an array
+              const resultInstance = Array.isArray(results) ? results[results.length - 1] : results
+
+              if (resultInstance.fields && resultInstance.fields.length > 0) {
+                const columns = resultInstance.fields.reduce(
+                  (accumulator: {[name: string]: any}, field) => {
+                    accumulator[field.name] = {header: field.name}
+
+                    return accumulator
+                  },
+                  {})
+
+                cli.table(
+                  resultInstance.rows,
+                  columns,
+                  {'no-truncate': true, output: outputFormat})
+              }
+
+              if (!outputFormat) {
+                // Only show the row count for the default format (undefined aka "table")
+                const rowSuffix = resultInstance.rowCount === 1 ? 'row' : 'rows'
+                this.log()
+                this.log(`(${resultInstance.rowCount ?? 0} ${rowSuffix})`)
+              }
+
+              pgClient.end()
+            }
+          })
+      })
+  }
+
+  private executeShellCommand(connInfo: FullConnectionInfo, shellCommand: string): void {
+    openSshTunnel(
+      connInfo,
       {debug: this.debug, info: this.log, warn: this.warn, error: this.error},
       sshClient => {
         const commandProc = tunnelServices.childProcessFactory.spawn(shellCommand, {
           env: {
             ...tunnelServices.nodeProcess.env,
             PGHOST: localPgHostname,
-            PGPORT: localPgPort.toString(),
-            PGDATABASE: dbConnInfo.dbName,
-            PGUSER: dbConnInfo.dbUsername,
-            PGPASSWORD: dbConnInfo.dbPassword,
+            PGPORT: connInfo.localPgPort.toString(),
+            PGDATABASE: connInfo.db.dbName,
+            PGUSER: connInfo.db.dbUsername,
+            PGPASSWORD: connInfo.db.dbPassword,
             DATABASE_URL:
-              `postgres://${dbConnInfo.dbUsername}:${dbConnInfo.dbPassword}@` +
-              `${localPgHostname}:${localPgPort}/${dbConnInfo.dbName}`,
+              `postgres://${connInfo.db.dbUsername}:${connInfo.db.dbPassword}@` +
+              `${localPgHostname}:${connInfo.localPgPort}/${connInfo.db.dbName}`,
           },
           shell: true,
           stdio: ['ignore', null, null], // Disable stdin but use the defaults for stdout and stderr
@@ -189,6 +300,7 @@ export default class RunCommand extends Command {
           commandProc.stdout.on('data', data => this.log(data.toString()))
         }
         if (commandProc.stderr) {
+          // Do not let the error function exit or it will generate an ugly stack trace
           commandProc.stderr.on('data', data => this.error(data.toString(), {exit: false}))
         }
       })

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -6,7 +6,12 @@ import {applyActionSpinner} from '../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../borealis-api'
 import {cliFlags, localPgHostname, processAddonAttachmentInfo} from '../../command-components'
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../heroku-api'
-import {openSshTunnel} from '../../ssh-tunneling'
+import {
+  DbConnectionInfo,
+  FullConnectionInfo,
+  openSshTunnel,
+  SshConnectionInfo,
+} from '../../ssh-tunneling'
 import tunnelServices from '../../tunnel-services'
 
 const keyboardKeyColour = color.italic
@@ -40,7 +45,7 @@ export default class TunnelCommand extends Command {
     const [sshConnInfo, dbConnInfo] =
       await this.createPersonalUsers(addonName, flags['write-access'])
 
-    const sshClient = this.connect(sshConnInfo, dbConnInfo, flags.port)
+    const sshClient = this.connect({ssh: sshConnInfo, db: dbConnInfo, localPgPort: flags.port})
 
     tunnelServices.nodeProcess.on('SIGINT', _ => {
       sshClient.end()
@@ -80,16 +85,14 @@ export default class TunnelCommand extends Command {
     }
   }
 
-  private connect(
-    sshConnInfo: SshConnectionInfo,
-    dbConnInfo: DbConnectionInfo,
-    localPgPort: number): SshClient {
+  private connect(connInfo: FullConnectionInfo): SshClient {
+    const localPgPort = connInfo.localPgPort
     const dbUrl =
-      `postgres://${dbConnInfo.dbUsername}:${dbConnInfo.dbPassword}` +
-      `@${localPgHostname}:${localPgPort}/${dbConnInfo.dbName}`
+      `postgres://${connInfo.db.dbUsername}:${connInfo.db.dbPassword}` +
+      `@${localPgHostname}:${localPgPort}/${connInfo.db.dbName}`
 
     return openSshTunnel(
-      {ssh: sshConnInfo, db: dbConnInfo, localPgPort: localPgPort},
+      connInfo,
       {debug: this.debug, info: this.log, warn: this.warn, error: this.error},
       _ => {
         this.log()
@@ -97,13 +100,11 @@ export default class TunnelCommand extends Command {
           'Secure tunnel established. ' +
           'Use the following values to connect to the database while the tunnel remains open:')
 
-        // It was tempting to use cli.table for this, but it has the unfortunate side effect of
-        // cutting off long values such that they are impossible to recover
-        this.log(`      ${connKeyColour('Username')}: ${connValueColour(dbConnInfo.dbUsername)}`)
-        this.log(`      ${connKeyColour('Password')}: ${connValueColour(dbConnInfo.dbPassword)}`)
+        this.log(`      ${connKeyColour('Username')}: ${connValueColour(connInfo.db.dbUsername)}`)
+        this.log(`      ${connKeyColour('Password')}: ${connValueColour(connInfo.db.dbPassword)}`)
         this.log(`          ${connKeyColour('Host')}: ${connValueColour(localPgHostname)}`)
         this.log(`          ${connKeyColour('Port')}: ${connValueColour(localPgPort.toString())}`)
-        this.log(` ${connKeyColour('Database name')}: ${connValueColour(dbConnInfo.dbName)}`)
+        this.log(` ${connKeyColour('Database name')}: ${connValueColour(connInfo.db.dbName)}`)
         this.log(`           ${connKeyColour('URL')}: ${connValueColour(dbUrl)}`)
 
         this.log()
@@ -129,20 +130,4 @@ export default class TunnelCommand extends Command {
       throw err
     }
   }
-}
-
-interface SshConnectionInfo {
-  sshHost: string;
-  sshPort?: number;
-  sshUsername: string;
-  sshPrivateKey: string;
-  publicSshHostKey: string;
-}
-
-interface DbConnectionInfo {
-  dbHost: string;
-  dbPort?: number;
-  dbName: string;
-  dbUsername: string;
-  dbPassword: string;
 }

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -4,7 +4,15 @@ import {HTTP, HTTPError} from 'http-call'
 import {Client as SshClient} from 'ssh2'
 import {applyActionSpinner} from '../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../borealis-api'
-import {cliFlags, localPgHostname, processAddonAttachmentInfo} from '../../command-components'
+import {
+  addonFlagName,
+  appFlagName,
+  cliFlags,
+  localPgHostname,
+  portFlagName,
+  processAddonAttachmentInfo,
+  writeAccessFlagName,
+} from '../../command-components'
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../heroku-api'
 import {
   DbConnectionInfo,
@@ -28,10 +36,10 @@ export default class TunnelCommand extends Command {
     'pgAdmin to interact with the add-on database.'
 
   static flags = {
-    addon: cliFlags.addon,
-    app: cliFlags.app,
-    port: cliFlags.port,
-    'write-access': cliFlags['write-access'],
+    [addonFlagName]: cliFlags.addon,
+    [appFlagName]: cliFlags.app,
+    [portFlagName]: cliFlags.port,
+    [writeAccessFlagName]: cliFlags.writeAccess,
   }
 
   async run() {
@@ -43,7 +51,7 @@ export default class TunnelCommand extends Command {
       this.error)
 
     const [sshConnInfo, dbConnInfo] =
-      await this.createPersonalUsers(addonName, flags['write-access'])
+      await this.createPersonalUsers(addonName, flags[writeAccessFlagName])
 
     const sshClient = this.connect({ssh: sshConnInfo, db: dbConnInfo, localPgPort: flags.port})
 

--- a/src/ssh-tunneling.test.ts
+++ b/src/ssh-tunneling.test.ts
@@ -289,7 +289,7 @@ describe('openSshTunnel', () => {
     verify(
       mockLoggerType.error(
         `Local port ${fakeCompleteConnInfo.localPgPort} is already in use. ` +
-        `Specify a different port number with the ${consoleColours.cliFlagName('--port')} flag.`,
+        `Specify a different port number with the ${consoleColours.cliFlag('--port')} flag.`,
         deepEqual({exit: false})))
       .once()
     verify(mockNodeProcessType.exit(1)).once()

--- a/src/ssh-tunneling.test.ts
+++ b/src/ssh-tunneling.test.ts
@@ -12,6 +12,7 @@ import {
   verify,
   when,
 } from 'ts-mockito'
+import {consoleColours} from './command-components'
 import {openSshTunnel} from './ssh-tunneling'
 import {expect} from './test-utils'
 import tunnelServices from './tunnel-services'
@@ -287,7 +288,8 @@ describe('openSshTunnel', () => {
     errorListener({code: 'EADDRINUSE'})
     verify(
       mockLoggerType.error(
-        `Local port ${fakeCompleteConnInfo.localPgPort} is already in use. Specify a different port number with the --port flag.`,
+        `Local port ${fakeCompleteConnInfo.localPgPort} is already in use. ` +
+        `Specify a different port number with the ${consoleColours.cliFlagName('--port')} flag.`,
         deepEqual({exit: false})))
       .once()
     verify(mockNodeProcessType.exit(1)).once()

--- a/src/ssh-tunneling.ts
+++ b/src/ssh-tunneling.ts
@@ -1,6 +1,6 @@
 import {Server} from 'net'
 import {Client as SshClient} from 'ssh2'
-import {defaultPorts, localPgHostname} from './command-components'
+import {consoleColours, defaultPorts, localPgHostname} from './command-components'
 import tunnelServices from './tunnel-services'
 
 /**
@@ -58,9 +58,10 @@ function initProxyServer(
     if (err.code === 'EADDRINUSE') {
       logger.debug(err)
 
-      // Do not let the error function throw an exception or it will generate an ugly stack trace
+      // Do not let the error function exit or it will generate an ugly stack trace
       logger.error(
-        `Local port ${connInfo.localPgPort} is already in use. Specify a different port number with the --port flag.`,
+        `Local port ${connInfo.localPgPort} is already in use. ` +
+        `Specify a different port number with the ${consoleColours.cliFlagName('--port')} flag.`,
         {exit: false})
 
       tunnelServices.nodeProcess.exit(1)

--- a/src/ssh-tunneling.ts
+++ b/src/ssh-tunneling.ts
@@ -1,6 +1,6 @@
 import {Server} from 'net'
 import {Client as SshClient} from 'ssh2'
-import {consoleColours, defaultPorts, localPgHostname} from './command-components'
+import {defaultPorts, formatCliFlagName, localPgHostname, portFlagName} from './command-components'
 import tunnelServices from './tunnel-services'
 
 /**
@@ -61,7 +61,7 @@ function initProxyServer(
       // Do not let the error function exit or it will generate an ugly stack trace
       logger.error(
         `Local port ${connInfo.localPgPort} is already in use. ` +
-        `Specify a different port number with the ${consoleColours.cliFlagName('--port')} flag.`,
+        `Specify a different port number with the ${formatCliFlagName(portFlagName)} flag.`,
         {exit: false})
 
       tunnelServices.nodeProcess.exit(1)

--- a/src/ssh-tunneling.ts
+++ b/src/ssh-tunneling.ts
@@ -116,7 +116,7 @@ export interface DbConnectionInfo {
   dbPassword: string;
 }
 
-interface FullConnectionInfo {
+export interface FullConnectionInfo {
   db: DbConnectionInfo;
   ssh: SshConnectionInfo;
   localPgPort: number;

--- a/src/tunnel-services.test.ts
+++ b/src/tunnel-services.test.ts
@@ -19,6 +19,20 @@ describe('tunnel services', () => {
     expect(tunnelServices.nodeProcess).to.equal(process)
   })
 
+  it('should have a valid Postgres client factory', () => {
+    const fakeUsername = 'my-user'
+
+    const result = tunnelServices.pgClientFactory.create({
+      host: 'my-host',
+      port: 58209,
+      database: 'my-db',
+      user: fakeUsername,
+      password: 'my-password',
+    })
+
+    expect(result.user).to.equal(fakeUsername)
+  })
+
   it('should have a valid SSH client factory', () => {
     const result = tunnelServices.sshClientFactory.create()
 

--- a/src/tunnel-services.ts
+++ b/src/tunnel-services.ts
@@ -1,5 +1,6 @@
 import childProcess, {SpawnOptions} from 'child_process'
 import {createServer, Socket} from 'net'
+import {Client as PgClient, ClientConfig as PgClientConfig} from 'pg'
 import {Client as SshClient} from 'ssh2'
 
 /**
@@ -12,6 +13,7 @@ export default {
     spawn: (command: string, options: SpawnOptions) => childProcess.spawn(command, options),
   },
   nodeProcess: process,
+  pgClientFactory: {create: (config: PgClientConfig) => new PgClient(config)},
   sshClientFactory: {create: () => new SshClient()},
   tcpServerFactory: {
     create: (connectionListener: (socket: Socket) => void) => createServer(connectionListener),

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,6 +499,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.18.tgz#37a0aab0560d1186da54ee5d62ff6a78cacb8c75"
   integrity sha512-YoTiIwdKxM3VLiY2sM05x4iGuTveYiCcDaUVmo1L5ndrXxPGW/NEoZu+pGcBirziomizcZsnsQoemikKcB2fRA==
 
+"@types/pg@^8.6.1":
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.6.1.tgz#099450b8dc977e8197a44f5229cedef95c8747f9"
+  integrity sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
 "@types/sinon@*":
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.2.tgz#f360d2f189c0fd433d14aeb97b9d705d7e4cc0e4"
@@ -788,6 +797,11 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer-writer@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
+  integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
 
 buffer@^5.5.0:
   version "5.7.1"
@@ -2514,6 +2528,11 @@ package-hash@^4.0.0:
     lodash.flattendeep "^4.4.0"
     release-zalgo "^1.0.0"
 
+packet-reader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
+  integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -2582,6 +2601,57 @@ pathval@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
+pg-connection-string@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
+  integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.4.1.tgz#0e71ce2c67b442a5e862a9c182172c37eda71e9c"
+  integrity sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ==
+
+pg-protocol@*, pg-protocol@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.5.0.tgz#b5dd452257314565e2d54ab3c132adc46565a6a0"
+  integrity sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==
+
+pg-types@^2.1.0, pg-types@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@^8.7.1:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.7.1.tgz#9ea9d1ec225980c36f94e181d009ab9f4ce4c471"
+  integrity sha512-7bdYcv7V6U3KAtWjpQJJBww0UEsWuh4yQ/EjNf2HeO/NnvKjpvhEIe/A/TleP6wtmSKnUnghs5A9jUoK6iDdkA==
+  dependencies:
+    buffer-writer "2.0.0"
+    packet-reader "1.0.0"
+    pg-connection-string "^2.5.0"
+    pg-pool "^3.4.1"
+    pg-protocol "^1.5.0"
+    pg-types "^2.1.0"
+    pgpass "1.x"
+
+pgpass@1.x:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.4.tgz#85eb93a83800b20f8057a2b029bf05abaf94ea9c"
+  integrity sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==
+  dependencies:
+    split2 "^3.1.1"
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
@@ -2593,6 +2663,28 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -2665,7 +2757,7 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-readable-stream@^3.1.1, readable-stream@^3.4.0:
+readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -2925,6 +3017,13 @@ spdx-license-ids@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz#8a595135def9592bda69709474f1cbeea7c2467f"
   integrity sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==
+
+split2@^3.1.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
+  integrity sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==
+  dependencies:
+    readable-stream "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -3350,6 +3449,11 @@ write-json-file@^4.1.1:
     make-dir "^3.0.0"
     sort-keys "^4.0.0"
     write-file-atomic "^3.0.0"
+
+xtend@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
The `borealis-pg:run` command now accepts a `--db-command` flag to execute raw SQL on the add-on database, in addition to the existing `--shell-command` flag. One may also specify the `--format` flag to control whether the results of a DB command are formatted as a text table (default), CSV, JSON or YAML.