### PR TITLE
Support database commands as files

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "lint": "eslint --max-warnings 0 --ext .ts --config .eslintrc .",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
-    "test": "nyc mocha --forbid-only \"src/**/*.test.ts\"",
+    "test": "nyc mocha --forbid-only 'src/**/*.test.ts'",
     "version": "oclif-dev readme && git add README.md"
   }
 }

--- a/src/command-components.ts
+++ b/src/command-components.ts
@@ -3,6 +3,7 @@ import {flags} from '@heroku-cli/command'
 import {AddOnAttachment} from '@heroku-cli/schema'
 
 export const consoleColours = {
+  cliCmdName: color.italic,
   cliFlag: color.bold.italic,
   envVar: color.bold,
   pgExtension: color.green,

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -36,8 +36,12 @@ const personalUserFlagName = 'personal-user'
 const shellCommandFlagName = 'shell-cmd'
 
 export default class RunCommand extends Command {
-  static description =
-    `runs a noninteractive command with a secure tunnel to a Borealis Isolated Postgres add-on
+  static description = `runs a command with a secure tunnel to a Borealis Isolated Postgres add-on
+
+An add-on Postgres database is, by design, inaccessible from outside of its
+virtual private cloud. As such, this operation establishes an ephemeral secure
+tunnel to an add-on database to execute a provided noninteractive command, then
+immediately closes the tunnel.
 
 A command can take the form of a database command or a shell command. In either
 case, it is executed using the Heroku application's dedicated database user by
@@ -47,8 +51,12 @@ Note that any tables, indexes, views or other objects that are created when
 connected as a personal user will be owned by that user rather than the
 application database user unless ownership is explicitly reassigned.
 
+By default, the user credentials that are provided allow read-only access to
+the add-on database; to enable read and write access, supply the ${formatCliFlagName(writeAccessFlagName)}
+flag.
+
 Database commands are raw statements (e.g. SQL, PL/pgSQL) that are sent over
-the secure tunnel to the add-on Postgres database to be executed verbatim with
+the secure tunnel to the add-on Postgres database to be executed verbatim, with
 the results then written to the console on stdout.
 
 Shell commands are useful for executing an application's database migration
@@ -61,7 +69,16 @@ the secure tunnel to the remote add-on Postgres database:
     - ${consoleColours.envVar('PGDATABASE')}
     - ${consoleColours.envVar('PGUSER')}
     - ${consoleColours.envVar('PGPASSWORD')}
-    - ${consoleColours.envVar('DATABASE_URL')}`
+    - ${consoleColours.envVar('DATABASE_URL')}
+
+See also the ${consoleColours.cliCmdName('borealis-pg:tunnel')} command to start an interactive session with an
+add-on Postgres database.`
+
+  static examples = [
+    `$ heroku borealis-pg:run --${addonFlagName} borealis-pg-hex-12345 --${shellCommandFlagName} './manage.py migrate' --${writeAccessFlagName}`,
+    `$ heroku borealis-pg:run --${appFlagName} sushi --${addonFlagName} DATABASE_URL --${dbCommandFlagName} 'SELECT * FROM hello_greeting' --${outputFormatFlagName} csv`,
+    `$ heroku borealis-pg:run --${appFlagName} sushi --${addonFlagName} BOREALIS_PG --${dbCommandFileFlagName} ~/scripts/example.sql --${personalUserFlagName}`,
+  ]
 
   static flags = {
     [addonFlagName]: cliFlags.addon,

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -8,6 +8,8 @@ import {
   addonFlagName,
   appFlagName,
   cliFlags,
+  consoleColours,
+  formatCliFlagName,
   localPgHostname,
   portFlagName,
   processAddonAttachmentInfo,
@@ -27,13 +29,24 @@ const connKeyColour = color.bold
 const connValueColour = color.grey
 
 export default class TunnelCommand extends Command {
-  static description =
-    'establishes a secure tunnel to a Borealis Isolated Postgres add-on\n' +
-    '\n' +
-    'This command allows for local, temporary connections to an add-on Postgres\n' +
-    'database that is, by design, otherwise inaccessible from outside of its\n' +
-    'virtual private cloud. Once a tunnel is established, use a tool such as psql or\n' +
-    'pgAdmin to interact with the add-on database.'
+  static description = `establishes a secure tunnel to a Borealis Isolated Postgres add-on
+
+This operation allows for a secure, temporary session connection to an add-on
+Postgres database that is, by design, otherwise inaccessible from outside of
+its virtual private cloud. Once a tunnel is established, use a tool such as
+psql or pgAdmin and the provided user credentials to interact with the add-on
+database. By default, the user credentials that are provided allow read-only
+access to the add-on database; to enable read and write access, supply the
+${formatCliFlagName(writeAccessFlagName)} flag.
+
+See also the ${consoleColours.cliCmdName('borealis-pg:run')} command to execute a noninteractive script for an
+add-on Postgres database.`
+
+  static examples = [
+    `$ heroku borealis-pg:tunnel --${addonFlagName} borealis-pg-hex-12345 --${writeAccessFlagName}`,
+    `$ heroku borealis-pg:tunnel --${appFlagName} sushi --${addonFlagName} DATABASE --${portFlagName} 54321`,
+    `$ heroku borealis-pg:tunnel --${appFlagName} sushi --${addonFlagName} BOREALIS_PG_URL`,
+  ]
 
   static flags = {
     [addonFlagName]: cliFlags.addon,


### PR DESCRIPTION
The `borealis-pg:run` command now supports a set of database commands supplied as a file to allow for more complex database operations/migrations.