### PR TITLE
Options to suppress PG extension errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 
 ## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.1.0...HEAD)
 - `borealis-pg:run` command to execute a noninteractive SQL or shell command for an add-on database
+- The `borealis-pg:extensions:install` command now includes the option to suppress the error when a Postgres extension is already installed
 
 ## [0.1.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/477321d...v0.1.0) - 2021-09-24
 First public pre-release version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 ## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.1.0...HEAD)
 - `borealis-pg:run` command to execute a noninteractive SQL or shell command for an add-on database
 - The `borealis-pg:extensions:install` command now includes the option to suppress the error when a Postgres extension is already installed
+- The `borealis-pg:extensions:remove` command now includes the option to suppress the error when a Postgres extension is not installed
 
 ## [0.1.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/477321d...v0.1.0) - 2021-09-24
 First public pre-release version

--- a/src/commands/borealis-pg/extensions/install.test.ts
+++ b/src/commands/borealis-pg/extensions/install.test.ts
@@ -92,6 +92,31 @@ describe('extension installation command', () => {
   testContextWithoutAppFlag
     .nock(
       borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api
+        .post(
+          `/heroku/resources/${fakeAddonName}/pg-extensions`,
+          {pgExtensionName: fakeExt1})
+        .reply(409, {reason: 'Already installed!'}))
+    .command([
+      'borealis-pg:extensions:install',
+      '--addon',
+      fakeAddonName,
+      '--suppress-conflict',
+      fakeExt1,
+    ])
+    .it(
+      'suppresses errors with the --suppress-conflict flag when an extension is already installed',
+      ctx => {
+        expect(ctx.stderr).to.contain(
+          `Installing Postgres extension ${fakeExt1} for add-on ${fakeAddonName}... !`)
+        expect(ctx.stderr).to.contain(`Extension ${fakeExt1} is already installed`)
+        expect(ctx.stdout).to.equal('')
+      })
+
+  testContextWithoutAppFlag
+    .nock(
+      borealisPgApiBaseUrl,
       api => api
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,

--- a/src/commands/borealis-pg/extensions/remove.test.ts
+++ b/src/commands/borealis-pg/extensions/remove.test.ts
@@ -88,6 +88,30 @@ describe('extension removal command', () => {
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
       api => api.delete(`/heroku/resources/${fakeAddonName}/pg-extensions/${fakeExt1}`)
+        .reply(404, {resourceType: 'extension'}))
+    .command([
+      'borealis-pg:extensions:remove',
+      '--confirm',
+      fakeExt1,
+      '--addon',
+      fakeAddonName,
+      '--suppress-missing',
+      fakeExt1,
+    ])
+    .it(
+      'suppresses errors with the --suppress-missing flag when an extension is not installed',
+      ctx => {
+        expect(ctx.stderr).to.contain(
+          `Removing Postgres extension ${fakeExt1} from add-on ${fakeAddonName}... !`)
+        expect(ctx.stderr).to.contain(`Extension ${fakeExt1} is not installed`)
+        expect(ctx.stdout).to.equal('')
+      })
+
+  testContextWithoutAppFlag
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.delete(`/heroku/resources/${fakeAddonName}/pg-extensions/${fakeExt1}`)
         .reply(200, {success: true}))
     .stdin(` ${fakeExt1} `, 500) // Fakes keyboard input for the confirmation prompt
     .command(['borealis-pg:extensions:remove', '-o', fakeAddonName, fakeExt1])


### PR DESCRIPTION
- The `borealis-pg:extensions:install` command now includes a `--suppress-conflict` flag to use an exit code of zero when the requested Postgres extension is already installed.
- The `borealis-pg:extensions:remove` command now includes a `--suppress-missing` flag to use an exit code of zero when the Postgres extension is not installed.