### PR TITLE
New link to PG extension support page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.2.1...HEAD)
+- Changed URL to Postgres extension support page
+
+## [0.2.1](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.2.0...v0.2.1)
+- Re-release of v0.2.0 to fix a build problem
+
 ## [0.2.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.1.0...v0.2.0)
 - Added the `borealis-pg:run` command to execute a noninteractive SQL or shell command for an add-on database
 - The `borealis-pg:extensions:install` command now includes the option to suppress the error when a Postgres extension is already installed

--- a/src/commands/borealis-pg/extensions/install.ts
+++ b/src/commands/borealis-pg/extensions/install.ts
@@ -31,8 +31,8 @@ part of the extension.
 If an extension has any unsatisfied dependencies, its dependencies will be
 installed automatically only if the ${formatCliFlagName(recursiveFlagName)} flag is provided.
 
-Details of supported extensions can be found here:
-https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Extensions.html`
+Details of all supported extensions can be found here:
+https://www.borealis-data.com/pg-extensions-support.html`
 
   static args = [
     cliArgs.pgExtension,


### PR DESCRIPTION
The `borealis-pg:extensions:install` command's description now links to the Borealis Data site's page listing which Postgres extensions are supported by add-on databases.