### PR TITLE
Action to publish to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Node.js
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ env.JOB_NODE_VERSION }}
           cache: yarn
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Node.js
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ env.JOB_NODE_VERSION }}
           cache: yarn

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on: workflow_dispatch
+
+env:
+  JOB_NODE_VERSION: '12.21.0'  # Chosen to match what is used internally by the Heroku CLI
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.JOB_NODE_VERSION }}
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Publish to npm
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds the `publish.yml` GitHub Actions workflow to publish the package to npm. Can only be triggered manually.