### PR TITLE
Indicate read/write permission in command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.2.2...HEAD)
+- `borealis-pg:run` and `borealis-pg:tunnel` now indicate in their output whether the user is read-only or read/write
+
 ## [0.2.2](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.2.1...v0.2.2)
 - Changed URL to Postgres extension support page
 

--- a/src/commands/borealis-pg/run.test.ts
+++ b/src/commands/borealis-pg/run.test.ts
@@ -414,7 +414,8 @@ describe('noninteractive run command', () => {
   defaultTestContext
     .command(['borealis-pg:run', '--addon', fakeAddonName, '--db-cmd', fakeDbCommand])
     .it('executes a database command with the default (table) format', ctx => {
-      expect(ctx.stderr).to.contain(`Configuring user session for add-on ${fakeAddonName}... done`)
+      expect(ctx.stderr).to.contain(
+        `Configuring read-only user session for add-on ${fakeAddonName}... done`)
 
       executeSshClientListener()
 
@@ -476,7 +477,8 @@ describe('noninteractive run command', () => {
   defaultTestContext
     .command(['borealis-pg:run', '-o', fakeAddonName, '-d', fakeDbCommand, '-f', 'table'])
     .it('executes a database command with multiple result entries', ctx => {
-      expect(ctx.stderr).to.contain(`Configuring user session for add-on ${fakeAddonName}... done`)
+      expect(ctx.stderr).to.contain(
+        `Configuring read-only user session for add-on ${fakeAddonName}... done`)
 
       const uniqueValue = 'feb88f0d-b630-4c8a-bff5-7167c06c2624'
 
@@ -602,7 +604,8 @@ describe('noninteractive run command', () => {
   defaultTestContext
     .command(['borealis-pg:run', '-o', fakeAddonName, '-d', fakeDbCommand])
     .it('executes a database command with no result', ctx => {
-      expect(ctx.stderr).to.contain(`Configuring user session for add-on ${fakeAddonName}... done`)
+      expect(ctx.stderr).to.contain(
+        `Configuring read-only user session for add-on ${fakeAddonName}... done`)
 
       executeSshClientListener()
 
@@ -618,7 +621,8 @@ describe('noninteractive run command', () => {
   defaultTestContext
     .command(['borealis-pg:run', '--addon', fakeAddonName, '--db-cmd-file', exampleFilePath])
     .it('executes a database command from a file', ctx => {
-      expect(ctx.stderr).to.contain(`Configuring user session for add-on ${fakeAddonName}... done`)
+      expect(ctx.stderr).to.contain(
+        `Configuring read-only user session for add-on ${fakeAddonName}... done`)
 
       executeSshClientListener()
 
@@ -761,7 +765,7 @@ describe('noninteractive run command', () => {
       executeSshClientListener()
 
       expect(ctx.stderr).to.endWith(
-        `Configuring user session for add-on ${fakeAddonName}... done\n`)
+        `Configuring read-only user session for add-on ${fakeAddonName}... done\n`)
       verify(mockChildProcessFactoryType.spawn(fakeShellCommand, anything())).once()
     })
 
@@ -774,8 +778,11 @@ describe('noninteractive run command', () => {
       '--shell-cmd',
       fakeShellCommand,
     ])
-    .it('configures the DB user with write access when requested', () => {
+    .it('configures the DB user with write access when requested', ctx => {
       executeSshClientListener()
+
+      expect(ctx.stderr).to.contain(
+        `Configuring read/write user session for add-on ${fakeAddonName}... done`)
 
       verify(mockChildProcessFactoryType.spawn(
         fakeShellCommand,

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -180,11 +180,12 @@ add-on Postgres database.`
         dbConnInfoPromise,
       ])
 
+      const accessLevelName = enableWriteAccess ? 'read/write' : 'read-only'
       const [sshConnInfoResult, dbConnInfoResult] =
         !showSpinner ?
           await fullConnInfoPromise :
           await applyActionSpinner(
-            `Configuring user session for add-on ${color.addon(addonInfo.addonName)}`,
+            `Configuring ${accessLevelName} user session for add-on ${color.addon(addonInfo.addonName)}`,
             fullConnInfoPromise,
           )
 

--- a/src/commands/borealis-pg/tunnel.test.ts
+++ b/src/commands/borealis-pg/tunnel.test.ts
@@ -274,7 +274,7 @@ describe('secure tunnel command', () => {
       listener()
 
       expect(ctx.stderr).to.endWith(
-        `Configuring personal user for add-on ${fakeAddonName}... done\n`)
+        `Configuring read-only user session for add-on ${fakeAddonName}... done\n`)
       expect(ctx.stdout).to.containIgnoreSpaces(`Database name: ${fakePgDbName}`)
     })
 
@@ -287,6 +287,8 @@ describe('secure tunnel command', () => {
 
       listener()
 
+      expect(ctx.stderr).to.endWith(
+        `Configuring read/write user session for add-on ${fakeAddonName}... done\n`)
       expect(ctx.stdout).to.containIgnoreSpaces(`Username: ${fakePgReadWriteUsername}`)
     })
 

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -78,9 +78,10 @@ add-on Postgres database.`
     addonName: string,
     enableWriteAccess: boolean): Promise<any[]> {
     const authorization = await createHerokuAuth(this.heroku, true)
+    const accessLevelName = enableWriteAccess ? 'read/write' : 'read-only'
     try {
       const [sshConnInfoResult, dbConnInfoResult] = await applyActionSpinner(
-        `Configuring personal user for add-on ${color.addon(addonName)}`,
+        `Configuring ${accessLevelName} user session for add-on ${color.addon(addonName)}`,
         Promise.allSettled([
           HTTP.post<SshConnectionInfo>(
             getBorealisPgApiUrl(`/heroku/resources/${addonName}/personal-ssh-users`),


### PR DESCRIPTION
The `borealis-pg:run` and `borealis-pg:tunnel` commands now indicate in their output (to stderr, actually) whether the user will have read-only or read/write permission.