### PR TITLE
Use domain name for tunnel connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 
 ## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.2.2...HEAD)
 - `borealis-pg:run` and `borealis-pg:tunnel` now indicate in their output whether the user is read-only or read/write
+- `borealis-pg:run` and `borealis-pg:tunnel` now use pg-tunnel.borealis-data.com for client connections (DNS entry points to 127.0.0.1)
 
 ## [0.2.2](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.2.1...v0.2.2)
 - Changed URL to Postgres extension support page

--- a/src/command-components.ts
+++ b/src/command-components.ts
@@ -9,7 +9,7 @@ export const consoleColours = {
   pgExtension: color.green,
 }
 
-export const localPgHostname = 'localhost'
+export const localPgHostname = 'pg-tunnel.borealis-data.com'
 
 export const defaultPorts = {
   pg: 5432,

--- a/src/commands/borealis-pg/run.test.ts
+++ b/src/commands/borealis-pg/run.test.ts
@@ -22,9 +22,9 @@ import {consoleColours} from '../../command-components'
 import {borealisPgApiBaseUrl, expect, herokuApiBaseUrl, test} from '../../test-utils'
 import tunnelServices from '../../tunnel-services'
 
-const localPgHostname = 'localhost'
+const localPgHostname = 'pg-tunnel.borealis-data.com'
 const defaultSshPort = 22
-const customSshPort = 50022
+const customSshPort = 52022
 const defaultPgPort = 5432
 const customPgPort = 65432
 

--- a/src/commands/borealis-pg/tunnel.test.ts
+++ b/src/commands/borealis-pg/tunnel.test.ts
@@ -15,11 +15,11 @@ import {
 import {borealisPgApiBaseUrl, expect, herokuApiBaseUrl, test} from '../../test-utils'
 import tunnelServices from '../../tunnel-services'
 
-const localPgHostname = 'localhost'
+const localPgHostname = 'pg-tunnel.borealis-data.com'
 const defaultSshPort = 22
 const customSshPort = 50022
 const defaultPgPort = 5432
-const customPgPort = 65432
+const customPgPort = 54321
 
 const fakeAddonName = 'borealis-pg-my-fake-addon'
 const fakeAddonAttachmentName = 'MY_COOL_DB'

--- a/src/ssh-tunneling.test.ts
+++ b/src/ssh-tunneling.test.ts
@@ -17,7 +17,7 @@ import {openSshTunnel} from './ssh-tunneling'
 import {expect} from './test-utils'
 import tunnelServices from './tunnel-services'
 
-const localPgHostname = 'localhost'
+const localPgHostname = 'pg-tunnel.borealis-data.com'
 const defaultSshPort = 22
 const customSshPort = 51022
 const defaultPgPort = 5432


### PR DESCRIPTION
The `borealis-pg:run` and `borealis-pg:tunnel` commands now use pg-tunnel.borealis-data.com rather than localhost for tunnel connections. The DNS A record for pg-tunnel.borealis-data.com simply points to 127.0.0.1, so the behaviour is functionally identical, but it should help to alleviate some confusion about what fields to provide to utilities like psql when connecting to the DB. For example, if one does not specify a host when running psql on a macOS/Linux machine, psql will attempt to use IPC to connect to the Postgres server because it assumes the server is installed locally. But now that `borealis-pg:tunnel` outputs a real domain name instead of "localhost", users will hopefully be compelled to provide the host rather than leaving it off.