### PR TITLE
Clarify that the tunnel command is non-interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.3.1...HEAD)
+- Clarified in the `borealis-pg:tunnel` command's output that it does not accept keyboard input
+
 ## [0.3.1](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.3.0...v0.3.1)
 - Updated dependencies to address a [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-3807) in the ansi-regex package
 

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -119,8 +119,7 @@ add-on Postgres database.`
       _ => {
         this.log()
         this.log(
-          'Secure tunnel established. ' +
-          'Use the following values to connect to the database while the tunnel remains open:')
+          'Secure tunnel established. Use the following values to connect to the database:')
 
         this.log(`      ${connKeyColour('Username')}: ${connValueColour(connInfo.db.dbUsername)}`)
         this.log(`      ${connKeyColour('Password')}: ${connValueColour(connInfo.db.dbPassword)}`)
@@ -128,6 +127,12 @@ add-on Postgres database.`
         this.log(`          ${connKeyColour('Port')}: ${connValueColour(localPgPort.toString())}`)
         this.log(` ${connKeyColour('Database name')}: ${connValueColour(connInfo.db.dbName)}`)
         this.log(`           ${connKeyColour('URL')}: ${connValueColour(dbUrl)}`)
+
+        this.log(`
+This process does not accept any keyboard input and will continue to run
+indefinitely. To interact with the database via a command line tool (e.g. psql)
+while the tunnel remains open, start and use a new terminal session. No extra
+steps are required to use a graphical user interface (e.g. pgAdmin).`)
 
         this.log()
         this.log(


### PR DESCRIPTION
Changes the output of the `borealis-pg:tunnel` command to make it clear that the command does not accept keyboard input. In other words, to execute a command line tool like psql against the database, one has to use a different terminal session.