### PR TITLE
Handle port conflicts on WIndows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 
 ## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.3.1...HEAD)
 - Clarified in the `borealis-pg:tunnel` command's output that it does not accept keyboard input
+- Handle port conflicts for secure tunnels on Windows
 
 ## [0.3.1](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.3.0...v0.3.1)
 - Updated dependencies to address a [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-3807) in the ansi-regex package

--- a/src/commands/borealis-pg/run.test.ts
+++ b/src/commands/borealis-pg/run.test.ts
@@ -1026,7 +1026,7 @@ describe('noninteractive run command', () => {
 
       errorListener({code: 'EADDRINUSE'})
 
-      expect(ctx.stderr).to.contain(`Local port ${customPgPort} is already in use`)
+      expect(ctx.stderr).to.contain(`Local port ${customPgPort} is not available`)
       verify(mockNodeProcessType.exit(1)).once()
     })
 

--- a/src/commands/borealis-pg/tunnel.test.ts
+++ b/src/commands/borealis-pg/tunnel.test.ts
@@ -415,7 +415,7 @@ describe('secure tunnel command', () => {
 
       errorListener({code: 'EADDRINUSE'})
 
-      expect(ctx.stderr).to.contain(`Local port ${customPgPort} is already in use`)
+      expect(ctx.stderr).to.contain(`Local port ${customPgPort} is not available`)
       verify(mockNodeProcessType.exit(1)).once()
     })
 

--- a/src/ssh-tunneling.test.ts
+++ b/src/ssh-tunneling.test.ts
@@ -287,8 +287,26 @@ describe('openSshTunnel', () => {
     errorListener({code: 'EADDRINUSE'})
     verify(
       mockLoggerType.error(
-        `Local port ${fakeCompleteConnInfo.localPgPort} is already in use. ` +
-        `Specify a different port number with the ${consoleColours.cliFlag('--port')} flag.`,
+        `Local port ${fakeCompleteConnInfo.localPgPort} is not available to listen on (port in ` +
+        `use). Specify a different port number with the ${consoleColours.cliFlag('--port')} flag.`,
+        deepEqual({exit: false})))
+      .once()
+    verify(mockNodeProcessType.exit(1)).once()
+  })
+
+  it('handles permission denied for port', () => {
+    openSshTunnel(fakeCompleteConnInfo, mockLoggerInstance, _ => true)
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, listener] = capture(mockTcpServerType.on).last()
+    const errorListener = listener as ((err: unknown) => void)
+
+    errorListener({code: 'EACCES'})
+    verify(
+      mockLoggerType.error(
+        `Local port ${fakeCompleteConnInfo.localPgPort} is not available to listen on ` +
+        '(permission denied). Specify a different port number with the ' +
+        `${consoleColours.cliFlag('--port')} flag.`,
         deepEqual({exit: false})))
       .once()
     verify(mockNodeProcessType.exit(1)).once()


### PR DESCRIPTION
When a local port is unavailable on Windows due to permissions, it throws an `EACCES` error instead of `EADDRINUSE`.