### PR TITLE
Require identity scope for Heroku authorizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.4.0...HEAD)
+- Require "identity" scope for Heroku authorizations
+
 ## [0.4.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.3.1...v0.4.0)
 - Clarified in the `borealis-pg:tunnel` command's output that it does not accept keyboard input
 - Handle port conflicts for secure tunnels on Windows

--- a/src/commands/borealis-pg/extensions/index.test.ts
+++ b/src/commands/borealis-pg/extensions/index.test.ts
@@ -15,7 +15,7 @@ const baseTestContext = test.stdout()
     .post('/oauth/authorizations', {
       description: 'Borealis PG CLI plugin temporary auth token',
       expires_in: 180,
-      scope: ['read'],
+      scope: ['read', 'identity'],
     })
     .reply(201, {id: fakeHerokuAuthId, access_token: {token: fakeHerokuAuthToken}})
     .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)

--- a/src/commands/borealis-pg/extensions/install.test.ts
+++ b/src/commands/borealis-pg/extensions/install.test.ts
@@ -22,7 +22,7 @@ const baseTestContext = test.stdout()
       .post('/oauth/authorizations', {
         description: 'Borealis PG CLI plugin temporary auth token',
         expires_in: 180,
-        scope: ['read'],
+        scope: ['read', 'identity'],
       })
       .reply(201, {id: fakeHerokuAuthId, access_token: {token: fakeHerokuAuthToken}})
       .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)

--- a/src/commands/borealis-pg/extensions/remove.test.ts
+++ b/src/commands/borealis-pg/extensions/remove.test.ts
@@ -17,7 +17,7 @@ const baseTestContext = test.stdout()
     api => api.post('/oauth/authorizations', {
       description: 'Borealis PG CLI plugin temporary auth token',
       expires_in: 180,
-      scope: ['read'],
+      scope: ['read', 'identity'],
     })
       .reply(201, {id: fakeHerokuAuthId, access_token: {token: fakeHerokuAuthToken}})
       .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -157,7 +157,7 @@ an add-on Postgres database.`
     usePersonalUser: boolean,
     enableWriteAccess: boolean,
     showSpinner: boolean): Promise<[SshConnectionInfo, DbConnectionInfo]> {
-    const authorization = await createHerokuAuth(this.heroku, true)
+    const authorization = await createHerokuAuth(this.heroku)
     try {
       const dbConnInfoPromise =
         !usePersonalUser ?

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -77,7 +77,7 @@ add-on Postgres database.`
   private async createPersonalUsers(
     addonName: string,
     enableWriteAccess: boolean): Promise<[SshConnectionInfo, DbConnectionInfo]> {
-    const authorization = await createHerokuAuth(this.heroku, true)
+    const authorization = await createHerokuAuth(this.heroku)
     const accessLevelName = enableWriteAccess ? 'read/write' : 'read-only'
     try {
       const [sshConnInfoResult, dbConnInfoResult] = await applyActionSpinner(

--- a/src/heroku-api.test.ts
+++ b/src/heroku-api.test.ts
@@ -23,24 +23,8 @@ describe('createHerokuAuth', () => {
     mockHerokuApiClientInstance = instance(mockHerokuApiClientType)
   })
 
-  it('requests an authorization without the "identity" scope by default', async () => {
+  it('requests a Heroku authorization', async () => {
     const result = await createHerokuAuth(mockHerokuApiClientInstance)
-
-    expect(result).to.equal(fakeAuthorization)
-
-    verify(mockHerokuApiClientType.post<OAuthAuthorization>(
-      '/oauth/authorizations',
-      deepEqual({
-        body: {
-          description: 'Borealis PG CLI plugin temporary auth token',
-          expires_in: 180,
-          scope: ['read'],
-        },
-      }))).once()
-  })
-
-  it('requests an authorization with the "identity" scope', async () => {
-    const result = await createHerokuAuth(mockHerokuApiClientInstance, true)
 
     expect(result).to.equal(fakeAuthorization)
 

--- a/src/heroku-api.ts
+++ b/src/heroku-api.ts
@@ -8,17 +8,14 @@ import {HTTPError} from 'http-call'
  * @param herokuApiClient The Heroku API client
  * @param includeIdentityScope Whether the authorization should include the "identity" scope
  */
-export async function createHerokuAuth(
-  herokuApiClient: APIClient,
-  includeIdentityScope = false): Promise<OAuthAuthorization> {
-  const scopes = includeIdentityScope ? ['read', 'identity'] : ['read']
+export async function createHerokuAuth(herokuApiClient: APIClient): Promise<OAuthAuthorization> {
   const response = await herokuApiClient.post<OAuthAuthorization>(
     '/oauth/authorizations',
     {
       body: {
         description: 'Borealis PG CLI plugin temporary auth token',
         expires_in: 180,
-        scope: scopes,
+        scope: ['read', 'identity'],
       },
     })
 


### PR DESCRIPTION
Includes the "identity" scope when requesting a Heroku authorization so that user identity can be logged to Heroku Logplex when requests like installing and removing PostgreSQL extensions are made to the Borealis API.