### PR TITLE
Change CLI flag references to "option"

### DIFF
--- a/src/command-components.test.ts
+++ b/src/command-components.test.ts
@@ -2,15 +2,15 @@ import color from '@heroku-cli/color'
 import {AddOnAttachment} from '@heroku-cli/schema'
 import {expect} from 'fancy-test'
 import {anyString, instance, mock, verify} from 'ts-mockito'
-import {consoleColours, formatCliFlagName, processAddonAttachmentInfo} from './command-components'
+import {consoleColours, formatCliOptionName, processAddonAttachmentInfo} from './command-components'
 
-describe('formatCliFlagName', () => {
-  it('returns a formatted CLI flag name', () => {
-    const flagName = 'my-fine-flag'
+describe('formatCliOptionName', () => {
+  it('returns a formatted CLI option name', () => {
+    const cliOptionName = 'my-fine-cli-option'
 
-    const result = formatCliFlagName(flagName)
+    const result = formatCliOptionName(cliOptionName)
 
-    expect(result).to.equal(consoleColours.cliFlag(`--${flagName}`))
+    expect(result).to.equal(consoleColours.cliOption(`--${cliOptionName}`))
   })
 })
 
@@ -96,7 +96,7 @@ describe('processAddonAttachmentInfo', () => {
   it('indicates when the add-on name does not correspond to an add-on', () => {
     const expectedMessage =
       `Add-on ${color.addon(fakeAddonName)} was not found. Consider trying again with the ` +
-      `${consoleColours.cliFlag('--app')} flag.`
+      `${consoleColours.cliOption('--app')} option.`
 
     const result = processAddonAttachmentInfo(
       null,

--- a/src/command-components.ts
+++ b/src/command-components.ts
@@ -4,7 +4,7 @@ import {AddOnAttachment} from '@heroku-cli/schema'
 
 export const consoleColours = {
   cliCmdName: color.italic,
-  cliFlag: color.bold.italic,
+  cliOption: color.bold.italic,
   envVar: color.bold,
   pgExtension: color.green,
 }
@@ -24,7 +24,7 @@ export const cliArgs = {
   pgExtension: {name: 'PG_EXTENSION', description: 'name of a Postgres extension', required: true},
 }
 
-export const cliFlags = {
+export const cliOptions = {
   addon: flags.string({
     char: 'o',
     description: 'name or ID of an add-on or one of its attachments',
@@ -56,20 +56,20 @@ export const cliFlags = {
   }),
 }
 
-export const addonFlagName = 'addon'
-export const appFlagName = 'app'
-export const portFlagName = 'port'
-export const writeAccessFlagName = 'write-access'
+export const addonOptionName = 'addon'
+export const appOptionName = 'app'
+export const portOptionName = 'port'
+export const writeAccessOptionName = 'write-access'
 
 /**
- * Formats the given CLI flag name for use in console output
+ * Formats the given CLI option name for use in console output
  *
- * @param name The flag name
+ * @param name The option name
  *
- * @returns The formatted flag name
+ * @returns The formatted option name
  */
-export function formatCliFlagName(name: string): string {
-  return consoleColours.cliFlag(`--${name}`)
+export function formatCliOptionName(name: string): string {
+  return consoleColours.cliOption(`--${name}`)
 }
 
 /**
@@ -107,6 +107,6 @@ export function processAddonAttachmentInfo(
   } else {
     return errorHandler(
       `Add-on ${color.addon(addonFilter.addonOrAttachment)} was not found. Consider trying again ` +
-      `with the ${formatCliFlagName(appFlagName)} flag.`)
+      `with the ${formatCliOptionName(appOptionName)} option.`)
   }
 }

--- a/src/commands/borealis-pg/extensions/index.test.ts
+++ b/src/commands/borealis-pg/extensions/index.test.ts
@@ -21,7 +21,7 @@ const baseTestContext = test.stdout()
     .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
     .reply(200))
 
-const testContextWithoutAppFlag = baseTestContext
+const testContextWithoutAppOption = baseTestContext
   .nock(herokuApiBaseUrl, api => api
     .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
     .reply(200, [
@@ -29,7 +29,7 @@ const testContextWithoutAppFlag = baseTestContext
       {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
     ]))
 
-const testContextWithAppFlag = baseTestContext
+const testContextWithAppOption = baseTestContext
   .nock(herokuApiBaseUrl, api => api
     .post(
       '/actions/addon-attachments/resolve',
@@ -39,7 +39,7 @@ const testContextWithAppFlag = baseTestContext
     ]))
 
 describe('extension list command', () => {
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -52,7 +52,7 @@ describe('extension list command', () => {
       expect(ctx.stdout).to.equal(`${fakeExt1}\n${fakeExt2}\n`)
     })
 
-  testContextWithAppFlag
+  testContextWithAppOption
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -73,7 +73,7 @@ describe('extension list command', () => {
         expect(ctx.stdout).to.equal(`${fakeExt1}\n${fakeExt2}\n`)
       })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.get(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -86,7 +86,7 @@ describe('extension list command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.get(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -97,7 +97,7 @@ describe('extension list command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.get(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -108,7 +108,7 @@ describe('extension list command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.get(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -146,7 +146,7 @@ describe('extension list command', () => {
     .stderr()
     .command(['borealis-pg:extensions'])
     .catch(/^Missing required flag:/)
-    .it('exits with an error if there is no add-on name flag', ctx => {
+    .it('exits with an error if there is no add-on name option', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 })

--- a/src/commands/borealis-pg/extensions/index.ts
+++ b/src/commands/borealis-pg/extensions/index.ts
@@ -4,9 +4,9 @@ import {HTTP, HTTPError} from 'http-call'
 import {applyActionSpinner} from '../../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../../borealis-api'
 import {
-  addonFlagName,
-  appFlagName,
-  cliFlags,
+  addonOptionName,
+  appOptionName,
+  cliOptions,
   consoleColours,
   processAddonAttachmentInfo,
 } from '../../../command-components'
@@ -18,8 +18,8 @@ export default class ListPgExtensionsCommand extends Command {
   static description = 'lists installed Postgres extensions for a Borealis Isolated Postgres add-on'
 
   static flags = {
-    [addonFlagName]: cliFlags.addon,
-    [appFlagName]: cliFlags.app,
+    [addonOptionName]: cliOptions.addon,
+    [appOptionName]: cliOptions.app,
   }
 
   async run() {

--- a/src/commands/borealis-pg/extensions/install.test.ts
+++ b/src/commands/borealis-pg/extensions/install.test.ts
@@ -28,7 +28,7 @@ const baseTestContext = test.stdout()
       .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
       .reply(200))
 
-const testContextWithoutAppFlag = baseTestContext
+const testContextWithoutAppOption = baseTestContext
   .nock(herokuApiBaseUrl, api => api
     .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
     .reply(200, [
@@ -36,7 +36,7 @@ const testContextWithoutAppFlag = baseTestContext
       {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
     ]))
 
-const testContextWithAppFlag = baseTestContext
+const testContextWithAppOption = baseTestContext
   .nock(herokuApiBaseUrl, api => api
     .post(
       '/actions/addon-attachments/resolve',
@@ -46,7 +46,7 @@ const testContextWithAppFlag = baseTestContext
     ]))
 
 describe('extension installation command', () => {
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -64,7 +64,7 @@ describe('extension installation command', () => {
         `- ${fakeExt1}: ${fakeExt1Schema}\n`)
     })
 
-  testContextWithAppFlag
+  testContextWithAppOption
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -89,7 +89,7 @@ describe('extension installation command', () => {
         `- ${fakeExt2}: ${fakeExt2Schema}\n`)
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -106,7 +106,7 @@ describe('extension installation command', () => {
       fakeExt1,
     ])
     .it(
-      'suppresses errors with the --suppress-conflict flag when an extension is already installed',
+      'suppresses errors with the --suppress-conflict option when an extension is already installed',
       ctx => {
         expect(ctx.stderr).to.contain(
           `Installing Postgres extension ${fakeExt1} for add-on ${fakeAddonName}... !`)
@@ -114,7 +114,7 @@ describe('extension installation command', () => {
         expect(ctx.stdout).to.equal('')
       })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api
@@ -138,7 +138,7 @@ describe('extension installation command', () => {
         `- ${fakeExt2}: ${fakeExt2Schema}\n`)
     })
 
-  testContextWithAppFlag
+  testContextWithAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api
@@ -176,7 +176,7 @@ describe('extension installation command', () => {
           `- ${fakeExt3}: ${fakeExt3Schema}\n`)
       })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api
@@ -209,7 +209,7 @@ describe('extension installation command', () => {
         `- ${fakeExt3}: ${fakeExt3Schema}\n`)
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api
@@ -231,7 +231,7 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -244,7 +244,7 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api
@@ -262,7 +262,7 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -273,7 +273,7 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -284,7 +284,7 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -295,7 +295,7 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -306,7 +306,7 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -343,7 +343,7 @@ describe('extension installation command', () => {
     .stderr()
     .command(['borealis-pg:extensions:install', fakeExt1])
     .catch(/^Missing required flag:/)
-    .it('exits with an error if there is no add-on name flag', ctx => {
+    .it('exits with an error if there is no add-on name option', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 

--- a/src/commands/borealis-pg/extensions/install.ts
+++ b/src/commands/borealis-pg/extensions/install.ts
@@ -5,12 +5,12 @@ import {HTTP, HTTPError} from 'http-call'
 import {applyActionSpinner} from '../../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../../borealis-api'
 import {
-  addonFlagName,
-  appFlagName,
+  addonOptionName,
+  appOptionName,
   cliArgs,
-  cliFlags,
+  cliOptions,
   consoleColours,
-  formatCliFlagName,
+  formatCliOptionName,
   processAddonAttachmentInfo,
 } from '../../../command-components'
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../../heroku-api'
@@ -18,8 +18,8 @@ import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../.
 const pgExtensionColour = consoleColours.pgExtension
 const dbSchemaColour = color.grey
 
-const recursiveFlagName = 'recursive'
-const suppressConflictFlagName = 'suppress-conflict'
+const recursiveOptionName = 'recursive'
+const suppressConflictOptionName = 'suppress-conflict'
 
 export default class InstallPgExtensionsCommand extends Command {
   static description = `installs a Postgres extension on a Borealis Isolated Postgres add-on
@@ -29,7 +29,7 @@ which may be used to store types, functions, tables or other objects that are
 part of the extension.
 
 If an extension has any unsatisfied dependencies, its dependencies will be
-installed automatically only if the ${formatCliFlagName(recursiveFlagName)} flag is provided.
+installed automatically only if the ${formatCliOptionName(recursiveOptionName)} option is provided.
 
 Details of all supported extensions can be found here:
 https://www.borealis-data.com/pg-extensions-support.html`
@@ -39,14 +39,14 @@ https://www.borealis-data.com/pg-extensions-support.html`
   ]
 
   static flags = {
-    [addonFlagName]: cliFlags.addon,
-    [appFlagName]: cliFlags.app,
-    [recursiveFlagName]: flags.boolean({
+    [addonOptionName]: cliOptions.addon,
+    [appOptionName]: cliOptions.app,
+    [recursiveOptionName]: flags.boolean({
       char: 'r',
       default: false,
       description: 'automatically install Postgres extension dependencies recursively',
     }),
-    [suppressConflictFlagName]: flags.boolean({
+    [suppressConflictOptionName]: flags.boolean({
       char: 's',
       default: false,
       description: 'suppress nonzero exit code when an extension is already installed',
@@ -56,7 +56,7 @@ https://www.borealis-data.com/pg-extensions-support.html`
   async run() {
     const {args, flags} = this.parse(InstallPgExtensionsCommand)
     const pgExtension = args[cliArgs.pgExtension.name]
-    const suppressConflict = flags[suppressConflictFlagName]
+    const suppressConflict = flags[suppressConflictOptionName]
     const authorization = await createHerokuAuth(this.heroku)
     const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
     const {addonName} = processAddonAttachmentInfo(
@@ -158,9 +158,9 @@ https://www.borealis-data.com/pg-extensions-support.html`
           this.error(
             `Extension ${pgExtensionColour(pgExtension)} has one or more unsatisfied ` +
             `dependencies. All of its dependencies (${dependenciesString}) must be installed.\n` +
-            `Run this command again with the ${formatCliFlagName(recursiveFlagName)} flag to ` +
-            'automatically and recursively install the extension and the missing extension(s) it ' +
-            'depends on.')
+            `Run this command again with the ${formatCliOptionName(recursiveOptionName)} option ` +
+            'to automatically and recursively install the extension and the missing extension(s) ' +
+            'it depends on.')
         } else {
           this.error(`${pgExtensionColour(pgExtension)} is not a supported Postgres extension`)
         }

--- a/src/commands/borealis-pg/extensions/remove.test.ts
+++ b/src/commands/borealis-pg/extensions/remove.test.ts
@@ -23,7 +23,7 @@ const baseTestContext = test.stdout()
       .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
       .reply(200))
 
-const testContextWithoutAppFlag = baseTestContext
+const testContextWithoutAppOption = baseTestContext
   .nock(herokuApiBaseUrl, api => api
     .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
     .reply(200, [
@@ -31,7 +31,7 @@ const testContextWithoutAppFlag = baseTestContext
       {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
     ]))
 
-const testContextWithAppFlag = baseTestContext
+const testContextWithAppOption = baseTestContext
   .nock(herokuApiBaseUrl, api => api
     .post(
       '/actions/addon-attachments/resolve',
@@ -41,7 +41,7 @@ const testContextWithAppFlag = baseTestContext
     ]))
 
 describe('extension removal command', () => {
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -61,7 +61,7 @@ describe('extension removal command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithAppFlag
+  testContextWithAppOption
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -83,7 +83,7 @@ describe('extension removal command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -99,7 +99,7 @@ describe('extension removal command', () => {
       fakeExt1,
     ])
     .it(
-      'suppresses errors with the --suppress-missing flag when an extension is not installed',
+      'suppresses errors with the --suppress-missing option when an extension is not installed',
       ctx => {
         expect(ctx.stderr).to.contain(
           `Removing Postgres extension ${fakeExt1} from add-on ${fakeAddonName}... !`)
@@ -107,7 +107,7 @@ describe('extension removal command', () => {
         expect(ctx.stdout).to.equal('')
       })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -141,11 +141,11 @@ describe('extension removal command', () => {
       fakeExt2,
     ])
     .catch(/^Invalid confirmation provided/)
-    .it('exits with an error if the confirm flag has the wrong value', ctx => {
+    .it('exits with an error if the confirm option has the wrong value', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.delete(`/heroku/resources/${fakeAddonName}/pg-extensions/${fakeExt1}`)
@@ -163,7 +163,7 @@ describe('extension removal command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.delete(`/heroku/resources/${fakeAddonName}/pg-extensions/${fakeExt1}`)
@@ -181,7 +181,7 @@ describe('extension removal command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.delete(`/heroku/resources/${fakeAddonName}/pg-extensions/${fakeExt2}`)
@@ -199,7 +199,7 @@ describe('extension removal command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.delete(`/heroku/resources/${fakeAddonName}/pg-extensions/${fakeExt1}`)
@@ -217,7 +217,7 @@ describe('extension removal command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppFlag
+  testContextWithoutAppOption
     .nock(
       borealisPgApiBaseUrl,
       api => api.delete(`/heroku/resources/${fakeAddonName}/pg-extensions/${fakeExt2}`)
@@ -268,7 +268,7 @@ describe('extension removal command', () => {
     .stderr()
     .command(['borealis-pg:extensions:remove', '-c', fakeExt2, fakeExt2])
     .catch(/^Missing required flag:/)
-    .it('exits with an error if there is no add-on name flag', ctx => {
+    .it('exits with an error if there is no add-on name option', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 

--- a/src/commands/borealis-pg/extensions/remove.ts
+++ b/src/commands/borealis-pg/extensions/remove.ts
@@ -5,10 +5,10 @@ import {HTTP, HTTPError} from 'http-call'
 import {applyActionSpinner} from '../../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../../borealis-api'
 import {
-  addonFlagName,
-  appFlagName,
+  addonOptionName,
+  appOptionName,
   cliArgs,
-  cliFlags,
+  cliOptions,
   consoleColours,
   processAddonAttachmentInfo,
 } from '../../../command-components'
@@ -16,8 +16,8 @@ import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../.
 
 const pgExtensionColour = consoleColours.pgExtension
 
-const confirmFlagName = 'confirm'
-const suppressMissingFlagName = 'suppress-missing'
+const confirmOptionName = 'confirm'
+const suppressMissingOptionName = 'suppress-missing'
 
 const addonResourceType = 'addon'
 
@@ -29,13 +29,13 @@ export default class RemovePgExtensionCommand extends Command {
   ]
 
   static flags = {
-    [addonFlagName]: cliFlags.addon,
-    [appFlagName]: cliFlags.app,
-    [confirmFlagName]: flags.string({
+    [addonOptionName]: cliOptions.addon,
+    [appOptionName]: cliOptions.app,
+    [confirmOptionName]: flags.string({
       char: 'c',
       description: 'bypass the prompt for confirmation by specifying the name of the extension',
     }),
-    [suppressMissingFlagName]: flags.boolean({
+    [suppressMissingOptionName]: flags.boolean({
       char: 's',
       default: false,
       description: 'suppress nonzero exit code when an extension is not installed',
@@ -45,7 +45,7 @@ export default class RemovePgExtensionCommand extends Command {
   async run() {
     const {args, flags} = this.parse(RemovePgExtensionCommand)
     const pgExtension = args[cliArgs.pgExtension.name]
-    const suppressMissing = flags[suppressMissingFlagName]
+    const suppressMissing = flags[suppressMissingOptionName]
 
     const confirmation = flags.confirm ?
       flags.confirm :

--- a/src/commands/borealis-pg/run.test.ts
+++ b/src/commands/borealis-pg/run.test.ts
@@ -126,7 +126,7 @@ const defaultTestContext = testContextWithDefaultUsers
       {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
     ]))
 
-const testContextWithAppFlag = testContextWithDefaultUsers
+const testContextWithAppOption = testContextWithDefaultUsers
   .nock(herokuApiBaseUrl, api => api
     .post(
       '/actions/addon-attachments/resolve',
@@ -295,7 +295,7 @@ describe('noninteractive run command', () => {
 
   defaultTestContext
     .command(['borealis-pg:run', '--addon', fakeAddonName, '--shell-cmd', fakeShellCommand])
-    .it('executes a shell command without a DB port flag', ctx => {
+    .it('executes a shell command without a DB port option', ctx => {
       executeSshClientListener()
 
       verify(mockChildProcessFactoryType.spawn(
@@ -360,7 +360,7 @@ describe('noninteractive run command', () => {
 
   defaultTestContext
     .command(['borealis-pg:run', '-o', fakeAddonName, '-p', '2345', '-e', fakeShellCommand])
-    .it('executes a shell command with a custom DB port flag', () => {
+    .it('executes a shell command with a custom DB port option', () => {
       executeSshClientListener()
 
       verify(mockChildProcessFactoryType.spawn(
@@ -751,7 +751,7 @@ describe('noninteractive run command', () => {
       verify(mockNodeProcessType.exit(1)).once()
     })
 
-  testContextWithAppFlag
+  testContextWithAppOption
     .command([
       'borealis-pg:run',
       '-a',
@@ -955,7 +955,7 @@ describe('noninteractive run command', () => {
     .stderr()
     .command(['borealis-pg:run', '-e', fakeShellCommand])
     .catch(/^Missing required flag:/)
-    .it('exits with an error if there is no add-on name flag', ctx => {
+    .it('exits with an error if there is no add-on name option', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 
@@ -963,9 +963,9 @@ describe('noninteractive run command', () => {
     .stderr()
     .command(['borealis-pg:run', '-o', fakeAddonName])
     .catch(
-      `Either ${consoleColours.cliFlag('--db-cmd')}, ${consoleColours.cliFlag('--db-cmd-file')} ` +
-      `or ${consoleColours.cliFlag('--shell-cmd')} must be specified`)
-    .it('exits with an error if there are no command flags', ctx => {
+      `Either ${consoleColours.cliOption('--db-cmd')}, ${consoleColours.cliOption('--db-cmd-file')} ` +
+      `or ${consoleColours.cliOption('--shell-cmd')} must be specified`)
+    .it('exits with an error if there are no command CLI options', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 
@@ -989,7 +989,7 @@ describe('noninteractive run command', () => {
       'yaml',
     ])
     .catch('--shell-cmd= cannot also be provided when using --format=')
-    .it('exits with an error if the --format flag is specified for a shell command', ctx => {
+    .it('exits with an error if the --format option is specified for a shell command', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -8,16 +8,16 @@ import {QueryResult} from 'pg'
 import {applyActionSpinner} from '../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../borealis-api'
 import {
-  addonFlagName,
-  appFlagName,
-  cliFlags,
+  addonOptionName,
+  appOptionName,
+  cliOptions,
   consoleColours,
   defaultPorts,
-  formatCliFlagName,
+  formatCliOptionName,
   localPgHostname,
-  portFlagName,
+  portOptionName,
   processAddonAttachmentInfo,
-  writeAccessFlagName,
+  writeAccessOptionName,
 } from '../../command-components'
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../heroku-api'
 import {
@@ -29,11 +29,11 @@ import {
 } from '../../ssh-tunneling'
 
 const defaultOutputFormat = 'table'
-const dbCommandFlagName = 'db-cmd'
-const dbCommandFileFlagName = 'db-cmd-file'
-const outputFormatFlagName = 'format'
-const personalUserFlagName = 'personal-user'
-const shellCommandFlagName = 'shell-cmd'
+const dbCommandOptionName = 'db-cmd'
+const dbCommandFileOptionName = 'db-cmd-file'
+const outputFormatOptionName = 'format'
+const personalUserOptionName = 'personal-user'
+const shellCommandOptionName = 'shell-cmd'
 
 export default class RunCommand extends Command {
   static description = `runs a command with a secure tunnel to a Borealis Isolated Postgres add-on
@@ -46,14 +46,14 @@ immediately closes the tunnel.
 A command can take the form of a database command or a shell command. In either
 case, it is executed using the Heroku application's dedicated database user by
 default, but it can be made to execute as a database user that is specifically
-tied to the current Heroku user account via the ${formatCliFlagName(personalUserFlagName)} flag instead.
+tied to the current Heroku user account via the ${formatCliOptionName(personalUserOptionName)} option instead.
 Note that any tables, indexes, views or other objects that are created when
 connected as a personal user will be owned by that user rather than the
 application database user unless ownership is explicitly reassigned.
 
 By default, the user credentials that are provided allow read-only access to
-the add-on database; to enable read and write access, supply the ${formatCliFlagName(writeAccessFlagName)}
-flag.
+the add-on database; to enable read and write access, supply the ${formatCliOptionName(writeAccessOptionName)}
+option.
 
 Database commands are raw statements (e.g. SQL, PL/pgSQL) that are sent over
 the secure tunnel to the add-on Postgres database to be executed verbatim, with
@@ -75,59 +75,59 @@ See also the ${consoleColours.cliCmdName('borealis-pg:tunnel')} command to start
 an add-on Postgres database.`
 
   static examples = [
-    `$ heroku borealis-pg:run --${addonFlagName} borealis-pg-hex-12345 --${shellCommandFlagName} './manage.py migrate' --${writeAccessFlagName}`,
-    `$ heroku borealis-pg:run --${appFlagName} sushi --${addonFlagName} DATABASE --${dbCommandFlagName} 'SELECT * FROM hello_greeting' --${outputFormatFlagName} csv`,
-    `$ heroku borealis-pg:run --${appFlagName} sushi --${addonFlagName} DATABASE_URL --${dbCommandFileFlagName} ~/scripts/example.sql --${personalUserFlagName}`,
+    `$ heroku borealis-pg:run --${addonOptionName} borealis-pg-hex-12345 --${shellCommandOptionName} './manage.py migrate' --${writeAccessOptionName}`,
+    `$ heroku borealis-pg:run --${appOptionName} sushi --${addonOptionName} DATABASE --${dbCommandOptionName} 'SELECT * FROM hello_greeting' --${outputFormatOptionName} csv`,
+    `$ heroku borealis-pg:run --${appOptionName} sushi --${addonOptionName} DATABASE_URL --${dbCommandFileOptionName} ~/scripts/example.sql --${personalUserOptionName}`,
   ]
 
   static flags = {
-    [addonFlagName]: cliFlags.addon,
-    [appFlagName]: cliFlags.app,
-    [dbCommandFlagName]: flags.string({
+    [addonOptionName]: cliOptions.addon,
+    [appOptionName]: cliOptions.app,
+    [dbCommandOptionName]: flags.string({
       char: 'd',
       description: 'database command to execute over the secure tunnel',
-      exclusive: [dbCommandFileFlagName, shellCommandFlagName],
+      exclusive: [dbCommandFileOptionName, shellCommandOptionName],
     }),
-    [dbCommandFileFlagName]: flags.string({
+    [dbCommandFileOptionName]: flags.string({
       char: 'i',
       description: 'UTF-8 file containing database command(s) to execute over the secure tunnel',
-      exclusive: [dbCommandFlagName, shellCommandFlagName],
+      exclusive: [dbCommandOptionName, shellCommandOptionName],
     }),
-    [outputFormatFlagName]: flags.enum({
+    [outputFormatOptionName]: flags.enum({
       char: 'f',
       description: `[default: ${defaultOutputFormat}] output format for database command results`,
-      exclusive: [shellCommandFlagName],
+      exclusive: [shellCommandOptionName],
       options: [defaultOutputFormat, 'csv', 'json', 'yaml'],
     }),
-    [personalUserFlagName]: flags.boolean({
+    [personalUserOptionName]: flags.boolean({
       char: 'u',
       description: 'run as a personal user rather than a user belonging to the Heroku application',
       default: false,
     }),
-    [portFlagName]: cliFlags.port,
-    [shellCommandFlagName]: flags.string({
+    [portOptionName]: cliOptions.port,
+    [shellCommandOptionName]: flags.string({
       char: 'e',
       description: 'shell command to execute when the secure tunnel is established',
-      exclusive: [dbCommandFlagName, dbCommandFileFlagName, outputFormatFlagName],
+      exclusive: [dbCommandOptionName, dbCommandFileOptionName, outputFormatOptionName],
     }),
-    [writeAccessFlagName]: cliFlags.writeAccess,
+    [writeAccessOptionName]: cliOptions.writeAccess,
   }
 
   async run() {
     const {flags} = this.parse(RunCommand)
-    const shellCommand = flags[shellCommandFlagName]
+    const shellCommand = flags[shellCommandOptionName]
 
     if (
-      (typeof flags[dbCommandFlagName] === 'undefined') &&
-      (typeof flags[dbCommandFileFlagName] === 'undefined') &&
+      (typeof flags[dbCommandOptionName] === 'undefined') &&
+      (typeof flags[dbCommandFileOptionName] === 'undefined') &&
       (typeof shellCommand === 'undefined')) {
       this.error(
-        `Either ${formatCliFlagName(dbCommandFlagName)}, ` +
-        `${formatCliFlagName(dbCommandFileFlagName)} or ` +
-        `${formatCliFlagName(shellCommandFlagName)} must be specified`)
+        `Either ${formatCliOptionName(dbCommandOptionName)}, ` +
+        `${formatCliOptionName(dbCommandFileOptionName)} or ` +
+        `${formatCliOptionName(shellCommandOptionName)} must be specified`)
     }
 
-    const dbCommand = this.getDbCommand(flags[dbCommandFlagName], flags[dbCommandFileFlagName])
+    const dbCommand = this.getDbCommand(flags[dbCommandOptionName], flags[dbCommandFileOptionName])
 
     const normalizedOutputFormat =
       (flags.format === defaultOutputFormat) ? undefined : flags.format
@@ -140,8 +140,8 @@ an add-on Postgres database.`
 
     const [sshConnInfo, dbConnInfo] = await this.prepareUsers(
       addonInfo,
-      flags[personalUserFlagName],
-      flags[writeAccessFlagName],
+      flags[personalUserOptionName],
+      flags[writeAccessOptionName],
       typeof normalizedOutputFormat === 'undefined')
     const fullConnInfo = {ssh: sshConnInfo, db: dbConnInfo, localPgPort: flags.port}
 

--- a/src/commands/borealis-pg/tunnel.test.ts
+++ b/src/commands/borealis-pg/tunnel.test.ts
@@ -89,7 +89,7 @@ const defaultTestContext = testContextWithDefaultUsers
       {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
     ]))
 
-const testContextWithAppFlag = testContextWithDefaultUsers
+const testContextWithAppOption = testContextWithDefaultUsers
   .nock(herokuApiBaseUrl, api => api
     .post(
       '/actions/addon-attachments/resolve',
@@ -228,7 +228,7 @@ describe('secure tunnel command', () => {
 
   defaultTestContext
     .command(['borealis-pg:tunnel', '--addon', fakeAddonName])
-    .it('outputs DB connection instructions without a DB port flag', ctx => {
+    .it('outputs DB connection instructions without a DB port option', ctx => {
       verify(mockSshClientType.on(anyString(), anyFunction())).once()
       const [event, listener] = capture(mockSshClientType.on).last()
       expect(event).to.equal('ready')
@@ -247,7 +247,7 @@ describe('secure tunnel command', () => {
 
   defaultTestContext
     .command(['borealis-pg:tunnel', '--addon', fakeAddonName, '--port', '15432'])
-    .it('outputs DB connection instructions for a custom DB port flag', ctx => {
+    .it('outputs DB connection instructions for a custom DB port option', ctx => {
       verify(mockSshClientType.on(anyString(), anyFunction())).once()
       const [event, listener] = capture(mockSshClientType.on).last()
       expect(event).to.equal('ready')
@@ -264,7 +264,7 @@ describe('secure tunnel command', () => {
       expect(ctx.stdout).to.containIgnoreCase('Ctrl+C')
     })
 
-  testContextWithAppFlag
+  testContextWithAppOption
     .command(['borealis-pg:tunnel', '--app', fakeHerokuAppName, '--addon', fakeAddonAttachmentName])
     .it('finds the correct add-on using its app and attachment names', ctx => {
       verify(mockSshClientType.on(anyString(), anyFunction())).once()
@@ -388,7 +388,7 @@ describe('secure tunnel command', () => {
     .stderr()
     .command(['borealis-pg:tunnel'])
     .catch(/^Missing required flag:/)
-    .it('exits with an error if there is no add-on name flag', ctx => {
+    .it('exits with an error if there is no add-on name option', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -5,15 +5,15 @@ import {Client as SshClient} from 'ssh2'
 import {applyActionSpinner} from '../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../borealis-api'
 import {
-  addonFlagName,
-  appFlagName,
-  cliFlags,
+  addonOptionName,
+  appOptionName,
+  cliOptions,
   consoleColours,
-  formatCliFlagName,
+  formatCliOptionName,
   localPgHostname,
-  portFlagName,
+  portOptionName,
   processAddonAttachmentInfo,
-  writeAccessFlagName,
+  writeAccessOptionName,
 } from '../../command-components'
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../heroku-api'
 import {
@@ -37,22 +37,22 @@ its virtual private cloud. Once a tunnel is established, use a tool such as
 psql or pgAdmin and the provided user credentials to interact with the add-on
 database. By default, the user credentials that are provided allow read-only
 access to the add-on database; to enable read and write access, supply the
-${formatCliFlagName(writeAccessFlagName)} flag.
+${formatCliOptionName(writeAccessOptionName)} option.
 
 See also the ${consoleColours.cliCmdName('borealis-pg:run')} command to execute a noninteractive script for an
 add-on Postgres database.`
 
   static examples = [
-    `$ heroku borealis-pg:tunnel --${addonFlagName} borealis-pg-hex-12345 --${writeAccessFlagName}`,
-    `$ heroku borealis-pg:tunnel --${appFlagName} sushi --${addonFlagName} DATABASE --${portFlagName} 54321`,
-    `$ heroku borealis-pg:tunnel --${appFlagName} sushi --${addonFlagName} DATABASE_URL`,
+    `$ heroku borealis-pg:tunnel --${addonOptionName} borealis-pg-hex-12345 --${writeAccessOptionName}`,
+    `$ heroku borealis-pg:tunnel --${appOptionName} sushi --${addonOptionName} DATABASE --${portOptionName} 54321`,
+    `$ heroku borealis-pg:tunnel --${appOptionName} sushi --${addonOptionName} DATABASE_URL`,
   ]
 
   static flags = {
-    [addonFlagName]: cliFlags.addon,
-    [appFlagName]: cliFlags.app,
-    [portFlagName]: cliFlags.port,
-    [writeAccessFlagName]: cliFlags.writeAccess,
+    [addonOptionName]: cliOptions.addon,
+    [appOptionName]: cliOptions.app,
+    [portOptionName]: cliOptions.port,
+    [writeAccessOptionName]: cliOptions.writeAccess,
   }
 
   async run() {
@@ -64,7 +64,7 @@ add-on Postgres database.`
       this.error)
 
     const [sshConnInfo, dbConnInfo] =
-      await this.createPersonalUsers(addonName, flags[writeAccessFlagName])
+      await this.createPersonalUsers(addonName, flags[writeAccessOptionName])
 
     const sshClient = this.connect({ssh: sshConnInfo, db: dbConnInfo, localPgPort: flags.port})
 

--- a/src/ssh-tunneling.test.ts
+++ b/src/ssh-tunneling.test.ts
@@ -288,7 +288,8 @@ describe('openSshTunnel', () => {
     verify(
       mockLoggerType.error(
         `Local port ${fakeCompleteConnInfo.localPgPort} is not available to listen on (port in ` +
-        `use). Specify a different port number with the ${consoleColours.cliFlag('--port')} flag.`,
+        `use). Specify a different port number with the ${consoleColours.cliOption('--port')} ` +
+        'option.',
         deepEqual({exit: false})))
       .once()
     verify(mockNodeProcessType.exit(1)).once()
@@ -306,7 +307,7 @@ describe('openSshTunnel', () => {
       mockLoggerType.error(
         `Local port ${fakeCompleteConnInfo.localPgPort} is not available to listen on ` +
         '(permission denied). Specify a different port number with the ' +
-        `${consoleColours.cliFlag('--port')} flag.`,
+        `${consoleColours.cliOption('--port')} option.`,
         deepEqual({exit: false})))
       .once()
     verify(mockNodeProcessType.exit(1)).once()

--- a/src/ssh-tunneling.ts
+++ b/src/ssh-tunneling.ts
@@ -2,7 +2,12 @@ import childProcess, {SpawnOptions} from 'child_process'
 import {createServer, Server, Socket} from 'net'
 import {Client as PgClient, ClientConfig as PgClientConfig} from 'pg'
 import {Client as SshClient} from 'ssh2'
-import {defaultPorts, formatCliFlagName, localPgHostname, portFlagName} from './command-components'
+import {
+  defaultPorts,
+  formatCliOptionName,
+  localPgHostname,
+  portOptionName,
+} from './command-components'
 
 const addressInUseErrorCode = 'EADDRINUSE'
 const permissionDeniedErrorCode = 'EACCES'
@@ -84,7 +89,7 @@ function initProxyServer(
       // Do not let the error function exit or it will generate an ugly stack trace
       logger.error(
         `Local port ${connInfo.localPgPort} is not available to listen on (${reason}). ` +
-        `Specify a different port number with the ${formatCliFlagName(portFlagName)} flag.`,
+        `Specify a different port number with the ${formatCliOptionName(portOptionName)} option.`,
         {exit: false})
 
       tunnelServices.nodeProcess.exit(1)


### PR DESCRIPTION
For consistency across the application and with general industry terminology, what were referred to as CLI "flags" are now referred to as "options" across the board.