### PR TITLE
Handle error when DB write access revoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.4.0...HEAD)
+- Handle cases where DB write access is disabled due to persistent storage limit violations
+
 ## [0.5.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.4.0...v0.5.0)
 - Require "identity" scope for Heroku authorizations
 

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -371,7 +371,12 @@ an add-on Postgres database.`
     const {flags} = this.parse(RunCommand)
 
     if (err instanceof HTTPError) {
-      if (err.statusCode === 404) {
+      if (err.statusCode === 403) {
+        this.error(
+          'Access to the add-on database has been temporarily revoked for personal users. ' +
+          'Generally this indicates the database has persistently exceeded its storage limit. ' +
+          'Try upgrading to a new add-on plan to restore access.')
+      } else if (err.statusCode === 404) {
         this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
       } else if (err.statusCode === 422) {
         this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)

--- a/src/commands/borealis-pg/tunnel.test.ts
+++ b/src/commands/borealis-pg/tunnel.test.ts
@@ -527,6 +527,32 @@ describe('secure tunnel command', () => {
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/personal-db-users`)
+        .reply(403, {reason: 'DB write access revoked'})
+        .post(`/heroku/resources/${fakeAddonName}/personal-ssh-users`)
+        .reply(
+          200,
+          {
+            sshHost: fakeSshHost,
+            sshUsername: fakeSshUsername,
+            sshPrivateKey: fakeSshPrivateKey,
+            publicSshHostKey: expectedSshHostKeyEntry,
+          }))
+    .command(['borealis-pg:tunnel', '--addon', fakeAddonName])
+    .catch(/^Access to the add-on database has been temporarily revoked for personal users/)
+    .it('exits with an error when DB write access is revoked', () => {
+      verify(mockTcpServerFactoryType.create(anyFunction())).never()
+      verify(mockSshClientFactoryType.create()).never()
+    })
+
+  baseTestContext
+    .nock(herokuApiBaseUrl, api => api
+      .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+      .reply(200, [
+        {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
+      ]))
+    .nock(
+      borealisPgApiBaseUrl,
+      api => api.post(`/heroku/resources/${fakeAddonName}/personal-db-users`)
         .reply(503, {reason: 'Server error!'})
         .post(`/heroku/resources/${fakeAddonName}/personal-ssh-users`)
         .reply(

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -146,7 +146,12 @@ steps are required to use a graphical user interface (e.g. pgAdmin).`)
     const {flags} = this.parse(TunnelCommand)
 
     if (err instanceof HTTPError) {
-      if (err.statusCode === 404) {
+      if (err.statusCode === 403) {
+        this.error(
+          'Access to the add-on database has been temporarily revoked for personal users. ' +
+          'Generally this indicates the database has persistently exceeded its storage limit. ' +
+          'Try upgrading to a new add-on plan to restore access.')
+      } else if (err.statusCode === 404) {
         this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
       } else if (err.statusCode === 422) {
         this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)


### PR DESCRIPTION
The Borealis PG server API responds with 403 Forbidden when DB write access has been disabled (e.g. due to persistent DB storage limit violations) and a CLI user attempts to use the `borealis-pg:run` or `borealis-pg:tunnel` commands with a personal DB user role.