### PR TITLE
Improve message when removing PG ext with dependents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.6.0...HEAD)
+- Improve error message when deleting a PostgreSQL extension with dependent objects
+
 ## [0.6.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.5.0...v0.6.0)
 - Handle cases where DB write access is disabled due to persistent storage limit violations
 

--- a/src/commands/borealis-pg/extensions/remove.test.ts
+++ b/src/commands/borealis-pg/extensions/remove.test.ts
@@ -176,7 +176,7 @@ describe('extension removal command', () => {
       fakeAddonName,
       fakeExt1,
     ])
-    .catch(new RegExp(`^Extension .*${fakeExt1}.* still has dependent extensions`))
+    .catch(new RegExp(`^Extension .*${fakeExt1}.* has dependent extensions or objects`))
     .it('exits with an error if the extension has dependents', ctx => {
       expect(ctx.stdout).to.equal('')
     })

--- a/src/commands/borealis-pg/extensions/remove.ts
+++ b/src/commands/borealis-pg/extensions/remove.ts
@@ -91,8 +91,8 @@ export default class RemovePgExtensionCommand extends Command {
     if (err instanceof HTTPError) {
       if (err.statusCode === 400) {
         this.error(
-          `Extension ${pgExtensionColour(pgExtension)} still has dependent extensions. ` +
-          'It can only be removed after its dependents are removed.')
+          `Extension ${pgExtensionColour(pgExtension)} has dependent extensions or objects. ` +
+          'It can only be removed after its dependents are removed first.')
       } else if (err.statusCode === 404) {
         if (err.body.resourceType === addonResourceType) {
           this.error(


### PR DESCRIPTION
When the `borealis-pg:extensions:remove` command attempts to delete an extension that has dependent objects in the database (e.g. another extension, a column's type, etc.), the error message more accurately reflects the range of possibilities.