### PR TITLE
Extension version and DB schema name in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.8.0...HEAD)
+- Additional extension info (version and DB schema name) in `borealis-pg:extensions` and `borealis-pg:extensions:install` command output
+
 ## [0.8.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.7.0...v0.8.0)
 - Adds the `borealis-pg:psql` command to launch an interactive psql session through a secure tunnel directly from the CLI
 

--- a/src/command-components.ts
+++ b/src/command-components.ts
@@ -5,6 +5,7 @@ import {AddOnAttachment} from '@heroku-cli/schema'
 export const consoleColours = {
   cliCmdName: color.italic,
   cliOption: color.bold.italic,
+  dataFieldValue: color.grey,
   envVar: color.bold,
   pgExtension: color.green,
 }

--- a/src/commands/borealis-pg/extensions/index.test.ts
+++ b/src/commands/borealis-pg/extensions/index.test.ts
@@ -7,7 +7,11 @@ const fakeHerokuAppName = 'my-fake-heroku-app'
 const fakeHerokuAuthToken = 'my-fake-heroku-auth-token'
 const fakeHerokuAuthId = 'my-fake-heroku-auth'
 const fakeExt1 = 'my-first-fake-pg-extension'
+const fakeExt1Schema = 'my-first-fake-db-schema'
+const fakeExt1Version = '16.8.5'
 const fakeExt2 = 'my-second-fake-pg-extension'
+const fakeExt2Schema = 'my-second-fake-db-schema'
+const fakeExt2Version = '0.7.15'
 
 const baseTestContext = test.stdout()
   .stderr()
@@ -44,12 +48,19 @@ describe('extension list command', () => {
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
       api => api.get(`/heroku/resources/${fakeAddonName}/pg-extensions`)
-        .reply(200, {extensions: [{name: fakeExt1}, {name: fakeExt2}]}))
+        .reply(200, {
+          extensions: [
+            {name: fakeExt1, schema: fakeExt1Schema, version: fakeExt1Version},
+            {name: fakeExt2, schema: fakeExt2Schema, version: fakeExt2Version},
+          ],
+        }))
     .command(['borealis-pg:extensions', '--addon', fakeAddonName])
     .it('outputs the list of installed extensions when given only an add-on name', ctx => {
       expect(ctx.stderr).to.endWith(
         `Fetching Postgres extension list for add-on ${fakeAddonName}... done\n`)
-      expect(ctx.stdout).to.equal(`${fakeExt1}\n${fakeExt2}\n`)
+      expect(ctx.stdout).to.equal(
+        `- ${fakeExt1} (version: ${fakeExt1Version}, schema: ${fakeExt1Schema})\n` +
+        `- ${fakeExt2} (version: ${fakeExt2Version}, schema: ${fakeExt2Schema})\n`)
     })
 
   testContextWithAppOption
@@ -57,7 +68,12 @@ describe('extension list command', () => {
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
       api => api.get(`/heroku/resources/${fakeAddonName}/pg-extensions`)
-        .reply(200, {extensions: [{name: fakeExt1}, {name: fakeExt2}]}))
+        .reply(200, {
+          extensions: [
+            {name: fakeExt2, schema: fakeExt2Schema, version: fakeExt2Version},
+            {name: fakeExt1, schema: fakeExt1Schema, version: fakeExt1Version},
+          ],
+        }))
     .command([
       'borealis-pg:extensions',
       '--addon',
@@ -70,7 +86,9 @@ describe('extension list command', () => {
       ctx => {
         expect(ctx.stderr).to.endWith(
           `Fetching Postgres extension list for add-on ${fakeAddonName}... done\n`)
-        expect(ctx.stdout).to.equal(`${fakeExt1}\n${fakeExt2}\n`)
+        expect(ctx.stdout).to.equal(
+          `- ${fakeExt2} (version: ${fakeExt2Version}, schema: ${fakeExt2Schema})\n` +
+          `- ${fakeExt1} (version: ${fakeExt1Version}, schema: ${fakeExt1Schema})\n`)
       })
 
   testContextWithoutAppOption

--- a/src/commands/borealis-pg/extensions/index.ts
+++ b/src/commands/borealis-pg/extensions/index.ts
@@ -13,6 +13,7 @@ import {
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../../heroku-api'
 
 const pgExtensionColour = consoleColours.pgExtension
+const pgExtMetadataColour = consoleColours.dataFieldValue
 
 export default class ListPgExtensionsCommand extends Command {
   static description = 'lists installed Postgres extensions for a Borealis Isolated Postgres add-on'
@@ -38,10 +39,14 @@ export default class ListPgExtensionsCommand extends Command {
           {headers: {Authorization: getBorealisPgAuthHeader(authorization)}}),
       )
 
-      const responseBody = response.body as {extensions: Array<{name: string}>}
+      const responseBody = response.body as
+        {extensions: Array<{name: string, schema: string, version: string}>}
       if (responseBody.extensions.length > 0) {
-        for (const extension of responseBody.extensions) {
-          this.log(pgExtensionColour(extension.name))
+        for (const extInfo of responseBody.extensions) {
+          this.log(
+            `- ${pgExtensionColour(extInfo.name)} ` +
+            `(version: ${pgExtMetadataColour(extInfo.version)}, ` +
+            `schema: ${pgExtMetadataColour(extInfo.schema)})`)
         }
       } else {
         this.warn('No extensions found')

--- a/src/commands/borealis-pg/extensions/install.test.ts
+++ b/src/commands/borealis-pg/extensions/install.test.ts
@@ -8,10 +8,13 @@ const fakeHerokuAuthToken = 'my-fake-heroku-auth-token'
 const fakeHerokuAuthId = 'my-fake-heroku-auth'
 const fakeExt1 = 'my-first-fake-pg-extension'
 const fakeExt1Schema = 'my-first-fake-pg-ext-schema'
+const fakeExt1Version = '1.11.111'
 const fakeExt2 = 'my-second-fake-pg-extension'
 const fakeExt2Schema = 'my-second-fake-pg-ext-schema'
+const fakeExt2Version = '22.2.0'
 const fakeExt3 = 'my-third-fake-pg-extension'
 const fakeExt3Schema = 'my-third-fake-pg-ext-schema'
+const fakeExt3Version = '3.3'
 const pgExtensionColour = color.green
 
 const baseTestContext = test.stdout()
@@ -54,14 +57,13 @@ describe('extension installation command', () => {
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
           {pgExtensionName: fakeExt1})
-        .reply(201, {pgExtensionSchema: fakeExt1Schema}))
+        .reply(201, {pgExtensionSchema: fakeExt1Schema, pgExtensionVersion: fakeExt1Version}))
     .command(['borealis-pg:extensions:install', '--addon', fakeAddonName, fakeExt1])
     .it('installs the requested extension when given only an add-on name', ctx => {
       expect(ctx.stderr).to.endWith(
         `Installing Postgres extension ${fakeExt1} for add-on ${fakeAddonName}... done\n`)
       expect(ctx.stdout).to.equal(
-        'Database schemas for installed extensions:\n' +
-        `- ${fakeExt1}: ${fakeExt1Schema}\n`)
+        `- ${fakeExt1} (version: ${fakeExt1Version}, schema: ${fakeExt1Schema})\n`)
     })
 
   testContextWithAppOption
@@ -72,7 +74,7 @@ describe('extension installation command', () => {
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
           {pgExtensionName: fakeExt2})
-        .reply(201, {pgExtensionSchema: fakeExt2Schema}))
+        .reply(201, {pgExtensionSchema: fakeExt2Schema, pgExtensionVersion: fakeExt2Version}))
     .command([
       'borealis-pg:extensions:install',
       '-o',
@@ -85,8 +87,7 @@ describe('extension installation command', () => {
       expect(ctx.stderr).to.endWith(
         `Installing Postgres extension ${fakeExt2} for add-on ${fakeAddonName}... done\n`)
       expect(ctx.stdout).to.equal(
-        'Database schemas for installed extensions:\n' +
-        `- ${fakeExt2}: ${fakeExt2Schema}\n`)
+        `- ${fakeExt2} (version: ${fakeExt2Version}, schema: ${fakeExt2Schema})\n`)
     })
 
   testContextWithoutAppOption
@@ -125,17 +126,16 @@ describe('extension installation command', () => {
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
           {pgExtensionName: fakeExt2})
-        .reply(201, {pgExtensionSchema: fakeExt2Schema})
+        .reply(201, {pgExtensionSchema: fakeExt2Schema, pgExtensionVersion: fakeExt2Version})
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
           {pgExtensionName: fakeExt3})
-        .reply(201, {pgExtensionSchema: fakeExt3Schema}))
+        .reply(201, {pgExtensionSchema: fakeExt3Schema, pgExtensionVersion: fakeExt3Version}))
     .command(['borealis-pg:extensions:install', '-r', '-o', fakeAddonName, fakeExt3])
     .it('installs the extension and its dependencies when given only an add-on name', ctx => {
       expect(ctx.stdout).to.equal(
-        'Database schemas for installed extensions:\n' +
-        `- ${fakeExt3}: ${fakeExt3Schema}\n` +
-        `- ${fakeExt2}: ${fakeExt2Schema}\n`)
+        `- ${fakeExt3} (version: ${fakeExt3Version}, schema: ${fakeExt3Schema})\n` +
+        `- ${fakeExt2} (version: ${fakeExt2Version}, schema: ${fakeExt2Schema})\n`)
     })
 
   testContextWithAppOption
@@ -153,11 +153,11 @@ describe('extension installation command', () => {
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
           {pgExtensionName: fakeExt3})
-        .reply(201, {pgExtensionSchema: fakeExt3Schema})
+        .reply(201, {pgExtensionSchema: fakeExt3Schema, pgExtensionVersion: fakeExt3Version})
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
           {pgExtensionName: fakeExt1})
-        .reply(201, {pgExtensionSchema: fakeExt1Schema}))
+        .reply(201, {pgExtensionSchema: fakeExt1Schema, pgExtensionVersion: fakeExt1Version}))
     .command([
       'borealis-pg:extensions:install',
       '--recursive',
@@ -171,9 +171,8 @@ describe('extension installation command', () => {
       'installs the extension and its dependencies when given add-on attachment and app names',
       ctx => {
         expect(ctx.stdout).to.equal(
-          'Database schemas for installed extensions:\n' +
-          `- ${fakeExt1}: ${fakeExt1Schema}\n` +
-          `- ${fakeExt3}: ${fakeExt3Schema}\n`)
+          `- ${fakeExt1} (version: ${fakeExt1Version}, schema: ${fakeExt1Schema})\n` +
+          `- ${fakeExt3} (version: ${fakeExt3Version}, schema: ${fakeExt3Schema})\n`)
       })
 
   testContextWithoutAppOption
@@ -191,22 +190,21 @@ describe('extension installation command', () => {
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
           {pgExtensionName: fakeExt3})
-        .reply(201, {pgExtensionSchema: fakeExt3Schema})
+        .reply(201, {pgExtensionSchema: fakeExt3Schema, pgExtensionVersion: fakeExt3Version})
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
           {pgExtensionName: fakeExt2})
-        .reply(201, {pgExtensionSchema: fakeExt2Schema})
+        .reply(201, {pgExtensionSchema: fakeExt2Schema, pgExtensionVersion: fakeExt2Version})
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
           {pgExtensionName: fakeExt1})
-        .reply(201, {pgExtensionSchema: fakeExt1Schema}))
+        .reply(201, {pgExtensionSchema: fakeExt1Schema, pgExtensionVersion: fakeExt1Version}))
     .command(['borealis-pg:extensions:install', '-r', '-o', fakeAddonName, fakeExt1])
     .it('installs the extension and its dependencies recursively', ctx => {
       expect(ctx.stdout).to.equal(
-        'Database schemas for installed extensions:\n' +
-        `- ${fakeExt1}: ${fakeExt1Schema}\n` +
-        `- ${fakeExt2}: ${fakeExt2Schema}\n` +
-        `- ${fakeExt3}: ${fakeExt3Schema}\n`)
+        `- ${fakeExt1} (version: ${fakeExt1Version}, schema: ${fakeExt1Schema})\n` +
+        `- ${fakeExt2} (version: ${fakeExt2Version}, schema: ${fakeExt2Schema})\n` +
+        `- ${fakeExt3} (version: ${fakeExt3Version}, schema: ${fakeExt3Schema})\n`)
     })
 
   testContextWithoutAppOption

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -26,7 +26,7 @@ import {
 
 const keyboardKeyColour = color.italic
 const connKeyColour = color.bold
-const connValueColour = color.grey
+const connValueColour = consoleColours.dataFieldValue
 
 export default class TunnelCommand extends Command {
   static description = `establishes a secure tunnel to a Borealis Isolated Postgres add-on


### PR DESCRIPTION
Adds PostgreSQL extension version to the console output from `borealis-pg:extensions:install` and adds both the version and DB schema name to output from `borealis-pg:extensions` to ensure output is as relevant and useful as possible.