### PR TITLE
Add-on DB users command

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         language:
-          - javascript
+          - javascript # TypeScript is covered by the JavaScript language scanner
 
     steps:
     - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 
 ## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.9.0...HEAD)
 - Adds the `borealis-pg:info` (alias: `borealis-pg`) command to retrieve details about an add-on DB
+- Adds the `borealis-pg:users` command to retrieve a list of active DB users for an add-on
 
 ## [0.9.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.8.0...v0.9.0)
 - Additional extension info (version and DB schema name) in `borealis-pg:extensions` and `borealis-pg:extensions:install` command output

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "scripts": {
     "clean": "rm -rf node_modules",
     "lint": "eslint --max-warnings 0 --ext .ts --config .eslintrc .",
-    "install": "node -e 'console.warn(\"NOTE: It is safe to ignore errors from gyp in the preceding output\")'",
+    "install": "node -e 'console.warn(\"NOTE: It is safe to ignore errors from gyp (if any) in the preceding output\")'",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "nyc mocha --forbid-only 'src/**/*.test.ts'",

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -1,7 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ConfigVars} from '@heroku-cli/schema'
-import {cli} from 'cli-ux'
+import cli from 'cli-ux'
 import {readFileSync} from 'fs'
 import {HTTP, HTTPError} from 'http-call'
 import {QueryResult} from 'pg'

--- a/src/commands/borealis-pg/users.test.ts
+++ b/src/commands/borealis-pg/users.test.ts
@@ -1,0 +1,213 @@
+import color from '@heroku-cli/color'
+import {borealisPgApiBaseUrl, expect, herokuApiBaseUrl, test} from '../../test-utils'
+
+const fakeAddonName = 'my-super-neat-fake-addon'
+const fakeAttachmentName = 'MY_SUPER_NEAT_FAKE_ADDON'
+const fakeHerokuAppName = 'my-super-neat-fake-app'
+
+const fakeAppReadOnlyUsername = 'app_ro_12345'
+const fakeAppReadWriteUsername = 'app_rw_67890'
+
+const fakePersonalUser1 = 'user1@example.com'
+const fakePersonalReadOnlyUsername1 = 'p_ro_abcdef'
+const fakePersonalReadWriteUsername1 = 'p_rw_abcdef'
+
+const fakePersonalUser2 = 'second-user@example.com'
+const fakePersonalReadOnlyUsername2 = 'p_ro_ghijkl'
+const fakePersonalReadWriteUsername2 = 'p_rw_ghijkl'
+
+const fakeHerokuAuthToken = 'my-fake-heroku-auth-token'
+const fakeHerokuAuthId = 'my-fake-heroku-auth'
+
+const baseTestContext = test.stdout()
+  .stderr()
+  .nock(herokuApiBaseUrl, api => api
+    .post('/oauth/authorizations', {
+      description: 'Borealis PG CLI plugin temporary auth token',
+      expires_in: 180,
+      scope: ['read', 'identity'],
+    })
+    .reply(201, {id: fakeHerokuAuthId, access_token: {token: fakeHerokuAuthToken}})
+    .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
+    .reply(200))
+
+const defaultTestContext = baseTestContext
+  .nock(herokuApiBaseUrl, api => api
+    .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+    .reply(200, [
+      {
+        addon: {name: fakeAddonName},
+        app: {name: fakeHerokuAppName},
+        name: fakeAttachmentName,
+      },
+      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
+    ]))
+
+describe('database users command', () => {
+  defaultTestContext
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.get(`/heroku/resources/${fakeAddonName}/db-users`)
+        .reply(
+          200,
+          {
+            users: [
+              {
+                displayName: null,
+                readOnlyUsername: fakeAppReadOnlyUsername,
+                readWriteUsername: fakeAppReadWriteUsername,
+                userType: 'app',
+              },
+              {
+                displayName: fakePersonalUser1,
+                readOnlyUsername: fakePersonalReadOnlyUsername1,
+                readWriteUsername: fakePersonalReadWriteUsername1,
+                userType: 'personal',
+              },
+              {
+                displayName: fakePersonalUser2,
+                readOnlyUsername: fakePersonalReadOnlyUsername2,
+                readWriteUsername: fakePersonalReadWriteUsername2,
+                userType: 'personal',
+              },
+            ],
+          }))
+    .command(['borealis-pg:users', '--addon', fakeAddonName])
+    .it('displays DB users for an add-on identified by add-on name', ctx => {
+      expect(ctx.stderr).to.contain(`Fetching user list for add-on ${fakeAddonName}... done`)
+
+      expect(ctx.stdout).to.containIgnoreSpaces(
+        ' Add-on User             DB Read-only Username DB Read/Write Username \n' +
+        ' ─────────────────────── ───────────────────── ────────────────────── \n' +
+        ` Heroku App User ${fakeAppReadOnlyUsername} ${fakeAppReadWriteUsername} \n` +
+        ` ${fakePersonalUser1} ${fakePersonalReadOnlyUsername1} ${fakePersonalReadWriteUsername1} \n` +
+        ` ${fakePersonalUser2} ${fakePersonalReadOnlyUsername2} ${fakePersonalReadWriteUsername2} \n`)
+    })
+
+  baseTestContext
+    .nock(herokuApiBaseUrl, api => api
+      .post(
+        '/actions/addon-attachments/resolve',
+        {addon_attachment: fakeAttachmentName, app: fakeHerokuAppName})
+      .reply(200, [
+        {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: fakeAttachmentName},
+      ]))
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.get(`/heroku/resources/${fakeAddonName}/db-users`)
+        .reply(
+          200,
+          {
+            users: [
+              {
+                displayName: null,
+                readOnlyUsername: fakeAppReadOnlyUsername,
+                readWriteUsername: fakeAppReadWriteUsername,
+                userType: 'app',
+              },
+              {
+                displayName: fakePersonalUser2,
+                readOnlyUsername: fakePersonalReadOnlyUsername2,
+                readWriteUsername: fakePersonalReadWriteUsername2,
+                userType: 'personal',
+              },
+              {
+                displayName: fakePersonalUser1,
+                readOnlyUsername: fakePersonalReadOnlyUsername1,
+                readWriteUsername: fakePersonalReadWriteUsername1,
+                userType: 'personal',
+              },
+            ],
+          }))
+    .command(['borealis-pg:users', '--app', fakeHerokuAppName, '--addon', fakeAttachmentName])
+    .it('displays DB users for an add-on identified by app and attachment name', ctx => {
+      expect(ctx.stderr).to.contain(`Fetching user list for add-on ${fakeAddonName}... done`)
+
+      expect(ctx.stdout).to.containIgnoreSpaces(
+        ' Add-on User             DB Read-only Username DB Read/Write Username \n' +
+        ' ─────────────────────── ───────────────────── ────────────────────── \n' +
+        ` Heroku App User ${fakeAppReadOnlyUsername} ${fakeAppReadWriteUsername} \n` +
+        ` ${fakePersonalUser2} ${fakePersonalReadOnlyUsername2} ${fakePersonalReadWriteUsername2} \n` +
+        ` ${fakePersonalUser1} ${fakePersonalReadOnlyUsername1} ${fakePersonalReadWriteUsername1} \n`)
+    })
+
+  defaultTestContext
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.get(`/heroku/resources/${fakeAddonName}/db-users`)
+        .reply(200, {users: []}))
+    .command(['borealis-pg:users', '--addon', fakeAddonName])
+    .it('displays a warning when there are no DB users', ctx => {
+      expect(ctx.stderr).to.contain(`Fetching user list for add-on ${fakeAddonName}... done`)
+      expect(ctx.stderr).to.contain('No users found')
+    })
+
+  test.stdout()
+    .stderr()
+    .nock(
+      herokuApiBaseUrl,
+      api => api.post('/oauth/authorizations')
+        .reply(201, {id: fakeHerokuAuthId})  // Note the access_token field is missing
+        .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
+        .reply(200)
+        .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+        .reply(200, [
+          {
+            addon: {name: fakeAddonName},
+            app: {name: fakeHerokuAppName},
+            name: fakeAttachmentName,
+          },
+        ]))
+    .command(['borealis-pg:users', '-o', fakeAddonName])
+    .catch('Log in to the Heroku CLI first!')
+    .it('exits with an error when there is no Heroku access token', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  test.stdout()
+    .stderr()
+    .command(['borealis-pg:users'])
+    .catch(/^Missing required flag:/)
+    .it('exits with an error when there is no add-on name option', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  defaultTestContext
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.get(`/heroku/resources/${fakeAddonName}/db-users`)
+        .reply(404, {reason: 'Not found'}))
+    .command(['borealis-pg:users', '--addon', fakeAddonName])
+    .catch(`Add-on ${color.addon(fakeAddonName)} is not a Borealis Isolated Postgres add-on`)
+    .it('exits with an error when the add-on was not found', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  defaultTestContext
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.get(`/heroku/resources/${fakeAddonName}/db-users`)
+        .reply(422, {reason: 'Not done yet'}))
+    .command(['borealis-pg:users', '--addon', fakeAddonName])
+    .catch(`Add-on ${color.addon(fakeAddonName)} is not finished provisioning`)
+    .it('exits with an error when the add-on is not finished provisioning', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  defaultTestContext
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.get(`/heroku/resources/${fakeAddonName}/db-users`)
+        .reply(500, {reason: 'Server error'}))
+    .command(['borealis-pg:users', '--addon', fakeAddonName])
+    .catch('Add-on service is temporarily unavailable. Try again later.')
+    .it('exits with an error when there is an API server error', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+})

--- a/src/commands/borealis-pg/users.ts
+++ b/src/commands/borealis-pg/users.ts
@@ -1,0 +1,99 @@
+import color from '@heroku-cli/color'
+import {Command} from '@heroku-cli/command'
+import cli from 'cli-ux'
+import {HTTP, HTTPError} from 'http-call'
+import {applyActionSpinner} from '../../async-actions'
+import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../borealis-api'
+import {
+  addonOptionName,
+  appOptionName,
+  cliOptions,
+  consoleColours,
+  formatCliOptionName,
+  processAddonAttachmentInfo,
+} from '../../command-components'
+import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../heroku-api'
+
+const cliCmdColour = consoleColours.cliCmdName
+
+export default class ListUsersCommand extends Command {
+  static description = `lists active database users for a Borealis Isolated Postgres add-on
+
+Note that this command's output only includes active add-on database user
+accounts. Personal read-only and read/write database user accounts are
+automatically created or reactivated for any user that has permission to
+access any app the add-on is attached to when that user runs one of the
+${cliCmdColour('borealis-pg:psql')} or ${cliCmdColour('borealis-pg:tunnel')} commands (or ${cliCmdColour('borealis-pg:run')} with the
+${formatCliOptionName('personal-user')} option). All personal database user accounts are automatically
+deactivated when the add-on's database user credentials are reset (for
+example, via the ${cliCmdColour('borealis-pg:users:reset')} command).`
+
+  static flags = {
+    [addonOptionName]: cliOptions.addon,
+    [appOptionName]: cliOptions.app,
+  }
+
+  async run() {
+    const {flags} = this.parse(ListUsersCommand)
+    const authorization = await createHerokuAuth(this.heroku)
+    const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
+    const {addonName} = processAddonAttachmentInfo(
+      attachmentInfos,
+      {addonOrAttachment: flags.addon, app: flags.app},
+      this.error)
+    try {
+      const response = await applyActionSpinner(
+        `Fetching user list for add-on ${color.addon(addonName)}`,
+        HTTP.get<{users: [DbUserInfo]}>(
+          getBorealisPgApiUrl(`/heroku/resources/${addonName}/db-users`),
+          {headers: {Authorization: getBorealisPgAuthHeader(authorization)}}),
+      )
+
+      if (response.body.users.length > 0) {
+        const columns: {[name: string]: any} = {
+          displayName: {header: 'Add-on User'},
+          readOnlyUsername: {header: 'DB Read-only Username'},
+          readWriteUsername: {header: 'DB Read/Write Username'},
+        }
+        const normalizedUsers = response.body.users.map(value => {
+          return {
+            displayName: (value.displayName ?? 'Heroku App User'),
+            readOnlyUsername: value.readOnlyUsername,
+            readWriteUsername: value.readWriteUsername,
+            userType: value.userType,
+          }
+        })
+
+        this.log()
+        cli.table(normalizedUsers, columns, {'no-truncate': true})
+      } else {
+        this.warn('No users found')
+      }
+    } finally {
+      await removeHerokuAuth(this.heroku, authorization.id as string)
+    }
+  }
+
+  async catch(err: any) {
+    const {flags} = this.parse(ListUsersCommand)
+
+    if (err instanceof HTTPError) {
+      if (err.statusCode === 404) {
+        this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
+      } else if (err.statusCode === 422) {
+        this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)
+      } else {
+        this.error('Add-on service is temporarily unavailable. Try again later.')
+      }
+    } else {
+      throw err
+    }
+  }
+}
+
+type DbUserInfo = {
+  displayName: string | null | undefined;
+  readOnlyUsername: string;
+  readWriteUsername: string;
+  userType: string;
+}


### PR DESCRIPTION
The new command retrieves and prints a table of currently active database user accounts (both for app and personal Heroku users).

Also improves the message that references gyp errors during installation slightly by no longer implying that gyp errors will always be present (they only show up if cpu-features failed to install, which will not be the case on all systems).