### PR TITLE
Improve description of personal DB user roles

### DIFF
--- a/src/commands/borealis-pg/psql.ts
+++ b/src/commands/borealis-pg/psql.ts
@@ -34,8 +34,15 @@ provide an interactive psql session. It requires that the psql command is
 installed on the local machine; generally, psql is installed along with
 PostgreSQL (https://www.postgresql.org/download/).
 
-By default, read-only user credentials are used to connect to the add-on
-database; to enable read and write access, supply the ${formatCliOptionName(writeAccessOptionName)} option.
+The psql session will be initiated as a database user role that is
+specifically tied to the current Heroku user account. By default the user role
+allows read-only access to the add-on database; to enable read and write
+access, supply the ${formatCliOptionName(writeAccessOptionName)} option.
+
+Note that any tables, indexes, views or other objects that are created when
+connected as a personal user role will be owned by that user role rather than
+the application database user role unless ownership is explicitly reassigned
+afterward (for example, by using the REASSIGN OWNED command).
 
 To override the path to the psql binary, supply the ${formatCliOptionName(binaryPathOptionName)} option.
 

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -47,16 +47,18 @@ tunnel to an add-on database to execute a provided noninteractive command, then
 immediately closes the tunnel.
 
 A command can take the form of a database command or a shell command. In either
-case, it is executed using the Heroku application's dedicated database user by
-default, but it can be made to execute as a database user that is specifically
-tied to the current Heroku user account via the ${formatCliOptionName(personalUserOptionName)} option instead.
-Note that any tables, indexes, views or other objects that are created when
-connected as a personal user will be owned by that user rather than the
-application database user unless ownership is explicitly reassigned.
+case, it is executed using the Heroku application's dedicated database user
+role by default, but it can be made to execute as a database user role that is
+specifically tied to the current Heroku user account via the ${formatCliOptionName(personalUserOptionName)}
+option instead. Note that any tables, indexes, views or other objects that are
+created when connected as a personal user role will be owned by that user role
+rather than the Heroku application user role unless ownership is explicitly
+reassigned afterward (for example, by using the REASSIGN OWNED command).
 
-By default, the user credentials that are provided allow read-only access to
-the add-on database; to enable read and write access, supply the ${formatCliOptionName(writeAccessOptionName)}
-option.
+Regardless of whether running as the Heroku application's database user role
+or as a personal user role, the command will have read-only access to the
+add-on database by default; to enable read and write access, supply the
+${formatCliOptionName(writeAccessOptionName)} option.
 
 Database commands are raw statements (e.g. SQL, PL/pgSQL) that are sent over
 the secure tunnel to the add-on Postgres database to be executed verbatim, with

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -35,9 +35,17 @@ This operation allows for a secure, temporary session connection to an add-on
 Postgres database that is, by design, otherwise inaccessible from outside of
 its virtual private cloud. Once a tunnel is established, use a tool such as
 psql or pgAdmin and the provided user credentials to interact with the add-on
-database. By default, the user credentials that are provided allow read-only
-access to the add-on database; to enable read and write access, supply the
-${formatCliOptionName(writeAccessOptionName)} option.
+database.
+
+The credentials that will be provided belong to a database user role that is
+specifically tied to the current Heroku user account. By default the user role
+allows read-only access to the add-on database; to enable read and write
+access, supply the ${formatCliOptionName(writeAccessOptionName)} option.
+
+Note that any tables, indexes, views or other objects that are created when
+connected as a personal user role will be owned by that user role rather than
+the application database user role unless ownership is explicitly reassigned
+afterward (for example, by using the REASSIGN OWNED command).
 
 See also the ${consoleColours.cliCmdName('borealis-pg:run')} command to execute a noninteractive script or the
 ${consoleColours.cliCmdName('borealis-pg:psql')} command to launch an interactive psql session directly.`

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -25,7 +25,7 @@ import {
 } from '../../ssh-tunneling'
 
 const keyboardKeyColour = color.italic
-const connKeyColour = consoleColours.dataFieldValue
+const connKeyColour = consoleColours.dataFieldName
 const connValueColour = consoleColours.dataFieldValue
 
 export default class TunnelCommand extends Command {

--- a/src/commands/borealis-pg/users.ts
+++ b/src/commands/borealis-pg/users.ts
@@ -17,16 +17,16 @@ import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../.
 const cliCmdColour = consoleColours.cliCmdName
 
 export default class ListUsersCommand extends Command {
-  static description = `lists active database users for a Borealis Isolated Postgres add-on
+  static description = `lists database user roles for a Borealis Isolated Postgres add-on
 
 Note that this command's output only includes active add-on database user
-accounts. Personal read-only and read/write database user accounts are
-automatically created or reactivated for any user that has permission to
-access any app the add-on is attached to when that user runs one of the
-${cliCmdColour('borealis-pg:psql')} or ${cliCmdColour('borealis-pg:tunnel')} commands (or ${cliCmdColour('borealis-pg:run')} with the
-${formatCliOptionName('personal-user')} option). All personal database user accounts are automatically
-deactivated when the add-on's database user credentials are reset (for
-example, via the ${cliCmdColour('borealis-pg:users:reset')} command).`
+roles. Personal read-only and read/write database user roles are automatically
+created or reactivated for any user that has permission to access any app the
+add-on is attached to when that user runs one of the ${cliCmdColour('borealis-pg:psql')} or
+${cliCmdColour('borealis-pg:tunnel')} commands (or ${cliCmdColour('borealis-pg:run')} with the ${formatCliOptionName('personal-user')}
+option). All personal database user roles are automatically deactivated when
+the add-on's database user credentials are reset (for example, via the
+${cliCmdColour('borealis-pg:users:reset')} command).`
 
   static flags = {
     [addonOptionName]: cliOptions.addon,


### PR DESCRIPTION
More thoroughly and consistently describes personal database user roles in the help output of affected commands.