### PR TITLE
Full DB credentials reset command

### DIFF
--- a/src/commands/borealis-pg/users/index.test.ts
+++ b/src/commands/borealis-pg/users/index.test.ts
@@ -1,5 +1,5 @@
 import color from '@heroku-cli/color'
-import {borealisPgApiBaseUrl, expect, herokuApiBaseUrl, test} from '../../test-utils'
+import {borealisPgApiBaseUrl, expect, herokuApiBaseUrl, test} from '../../../test-utils'
 
 const fakeAddonName = 'my-super-neat-fake-addon'
 const fakeAttachmentName = 'MY_SUPER_NEAT_FAKE_ADDON'

--- a/src/commands/borealis-pg/users/index.ts
+++ b/src/commands/borealis-pg/users/index.ts
@@ -2,8 +2,8 @@ import color from '@heroku-cli/color'
 import {Command} from '@heroku-cli/command'
 import cli from 'cli-ux'
 import {HTTP, HTTPError} from 'http-call'
-import {applyActionSpinner} from '../../async-actions'
-import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../borealis-api'
+import {applyActionSpinner} from '../../../async-actions'
+import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../../borealis-api'
 import {
   addonOptionName,
   appOptionName,
@@ -11,8 +11,8 @@ import {
   consoleColours,
   formatCliOptionName,
   processAddonAttachmentInfo,
-} from '../../command-components'
-import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../heroku-api'
+} from '../../../command-components'
+import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../../heroku-api'
 
 const cliCmdColour = consoleColours.cliCmdName
 
@@ -20,7 +20,8 @@ export default class ListUsersCommand extends Command {
   static description = `lists database user roles for a Borealis Isolated Postgres add-on
 
 Note that this command's output only includes active add-on database user
-roles. Personal read-only and read/write database user roles are automatically
+roles. The Heroku application's database user roles are always present.
+Personal read-only and read/write database user roles are automatically
 created or reactivated for any user that has permission to access any app the
 add-on is attached to when that user runs one of the ${cliCmdColour('borealis-pg:psql')} or
 ${cliCmdColour('borealis-pg:tunnel')} commands (or ${cliCmdColour('borealis-pg:run')} with the ${formatCliOptionName('personal-user')}

--- a/src/commands/borealis-pg/users/reset.test.ts
+++ b/src/commands/borealis-pg/users/reset.test.ts
@@ -1,0 +1,132 @@
+import color from '@heroku-cli/color'
+import {borealisPgApiBaseUrl, expect, herokuApiBaseUrl, test} from '../../../test-utils'
+
+const fakeAddonName = 'my-super-neat-fake-addon'
+const fakeAttachmentName = 'MY_SUPER_NEAT_FAKE_ADDON'
+const fakeHerokuAppName = 'my-super-neat-fake-app'
+
+const fakeHerokuAuthToken = 'my-fake-heroku-auth-token'
+const fakeHerokuAuthId = 'my-fake-heroku-auth'
+
+const baseTestContext = test.stdout()
+  .stderr()
+  .nock(herokuApiBaseUrl, api => api
+    .post('/oauth/authorizations', {
+      description: 'Borealis PG CLI plugin temporary auth token',
+      expires_in: 180,
+      scope: ['read', 'identity'],
+    })
+    .reply(201, {id: fakeHerokuAuthId, access_token: {token: fakeHerokuAuthToken}})
+    .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
+    .reply(200))
+
+const defaultTestContext = baseTestContext
+  .nock(herokuApiBaseUrl, api => api
+    .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+    .reply(200, [
+      {
+        addon: {name: fakeAddonName},
+        app: {name: fakeHerokuAppName},
+        name: fakeAttachmentName,
+      },
+      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
+    ]))
+
+describe('database credentials reset command', () => {
+  defaultTestContext
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.delete(`/heroku/resources/${fakeAddonName}/db-users/credentials`)
+        .reply(200, {}))
+    .command(['borealis-pg:users:reset', '--addon', fakeAddonName])
+    .it('resets all DB credentials for an add-on identified by add-on name', ctx => {
+      expect(ctx.stderr).to.contain(
+        `Resetting all database credentials for add-on ${fakeAddonName}... done`)
+    })
+
+  baseTestContext
+    .nock(herokuApiBaseUrl, api => api
+      .post(
+        '/actions/addon-attachments/resolve',
+        {addon_attachment: fakeAttachmentName, app: fakeHerokuAppName})
+      .reply(200, [
+        {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: fakeAttachmentName},
+      ]))
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.delete(`/heroku/resources/${fakeAddonName}/db-users/credentials`)
+        .reply(200, {}))
+    .command(['borealis-pg:users:reset', '--app', fakeHerokuAppName, '--addon', fakeAttachmentName])
+    .it('resets all DB credentials for an add-on identified by app and attachment name', ctx => {
+      expect(ctx.stderr).to.contain(
+        `Resetting all database credentials for add-on ${fakeAddonName}... done`)
+    })
+
+  test.stdout()
+    .stderr()
+    .nock(
+      herokuApiBaseUrl,
+      api => api.post('/oauth/authorizations')
+        .reply(201, {id: fakeHerokuAuthId})  // Note the access_token field is missing
+        .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
+        .reply(200)
+        .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+        .reply(200, [
+          {
+            addon: {name: fakeAddonName},
+            app: {name: fakeHerokuAppName},
+            name: fakeAttachmentName,
+          },
+        ]))
+    .command(['borealis-pg:users:reset', '-o', fakeAddonName])
+    .catch('Log in to the Heroku CLI first!')
+    .it('exits with an error when there is no Heroku access token', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  test.stdout()
+    .stderr()
+    .command(['borealis-pg:users:reset'])
+    .catch(/^Missing required flag:/)
+    .it('exits with an error when there is no add-on name option', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  defaultTestContext
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.delete(`/heroku/resources/${fakeAddonName}/db-users/credentials`)
+        .reply(404, {reason: 'Not found'}))
+    .command(['borealis-pg:users:reset', '--addon', fakeAddonName])
+    .catch(`Add-on ${color.addon(fakeAddonName)} is not a Borealis Isolated Postgres add-on`)
+    .it('exits with an error when the add-on was not found', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  defaultTestContext
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.delete(`/heroku/resources/${fakeAddonName}/db-users/credentials`)
+        .reply(422, {reason: 'Not done yet'}))
+    .command(['borealis-pg:users:reset', '--addon', fakeAddonName])
+    .catch(`Add-on ${color.addon(fakeAddonName)} is not finished provisioning`)
+    .it('exits with an error when the add-on is not finished provisioning', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  defaultTestContext
+    .nock(
+      borealisPgApiBaseUrl,
+      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
+      api => api.delete(`/heroku/resources/${fakeAddonName}/db-users/credentials`)
+        .reply(500, {reason: 'Server error'}))
+    .command(['borealis-pg:users:reset', '--addon', fakeAddonName])
+    .catch('Add-on service is temporarily unavailable. Try again later.')
+    .it('exits with an error when there is an API server error', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+})

--- a/src/commands/borealis-pg/users/reset.ts
+++ b/src/commands/borealis-pg/users/reset.ts
@@ -1,0 +1,79 @@
+import color from '@heroku-cli/color'
+import {Command} from '@heroku-cli/command'
+import {HTTP, HTTPError} from 'http-call'
+import {applyActionSpinner} from '../../../async-actions'
+import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../../borealis-api'
+import {
+  addonOptionName,
+  appOptionName,
+  cliOptions,
+  consoleColours,
+  formatCliOptionName,
+  processAddonAttachmentInfo,
+} from '../../../command-components'
+import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../../heroku-api'
+
+const cliCmdColour = consoleColours.cliCmdName
+
+export default class ResetUsersCommand extends Command {
+  static description =
+    `resets all database credentials for a Borealis Isolated Postgres add-on
+
+The Heroku application's database user roles will be assigned new, random
+passwords and the application's config vars will be updated immediately and
+automatically with the new credentials. Generally this will happen with no
+visible disruption for the Heroku application's end users, but there is a very
+brief window in which the database may reject new database connections
+(typically for only a few seconds), so plan accordingly.
+
+Any active personal database user roles will be deactivated by this operation,
+which means that anyone that is currently connected to the database with a
+personal user role will be immediately disconnected. Rest assured that any
+tables, indexes, views or other objects that are are owned by a personal user
+role will not be affected (the user roles and the objects they own will
+continue to exist). A personal user role that has been deactivated will be
+automatically reactivated when the affected user runs one of the
+${cliCmdColour('borealis-pg:psql')} or ${cliCmdColour('borealis-pg:tunnel')} commands (or ${cliCmdColour('borealis-pg:run')} with the
+${formatCliOptionName('personal-user')} option).`
+
+  static flags = {
+    [addonOptionName]: cliOptions.addon,
+    [appOptionName]: cliOptions.app,
+  }
+
+  async run() {
+    const {flags} = this.parse(ResetUsersCommand)
+    const authorization = await createHerokuAuth(this.heroku)
+    const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
+    const {addonName} = processAddonAttachmentInfo(
+      attachmentInfos,
+      {addonOrAttachment: flags.addon, app: flags.app},
+      this.error)
+    try {
+      await applyActionSpinner(
+        `Resetting all database credentials for add-on ${color.addon(addonName)}`,
+        HTTP.delete<{success: boolean}>(
+          getBorealisPgApiUrl(`/heroku/resources/${addonName}/db-users/credentials`),
+          {headers: {Authorization: getBorealisPgAuthHeader(authorization)}}),
+      )
+    } finally {
+      await removeHerokuAuth(this.heroku, authorization.id as string)
+    }
+  }
+
+  async catch(err: any) {
+    const {flags} = this.parse(ResetUsersCommand)
+
+    if (err instanceof HTTPError) {
+      if (err.statusCode === 404) {
+        this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
+      } else if (err.statusCode === 422) {
+        this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)
+      } else {
+        this.error('Add-on service is temporarily unavailable. Try again later.')
+      }
+    } else {
+      throw err
+    }
+  }
+}


### PR DESCRIPTION
The new command rotates the passwords of the Heroku app's database user roles and deactivates all of the personal database user roles.