### PR TITLE
Optional --addon option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 ## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.9.0...HEAD)
 - Adds the `borealis-pg:info` (alias: `borealis-pg`) command to retrieve details about an add-on DB
 - Adds the `borealis-pg:users` command to retrieve a list of active DB users for an add-on
+- The `--addon` option is no longer required when there is only one Borealis Isolated Postgres add-on attached to an app
 
 ## [0.9.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.8.0...v0.9.0)
 - Additional extension info (version and DB schema name) in `borealis-pg:extensions` and `borealis-pg:extensions:install` command output

--- a/src/async-actions.test.ts
+++ b/src/async-actions.test.ts
@@ -19,7 +19,7 @@ describe('applyActionSpinner', () => {
       const expectedError = new Error('my-bad-error')
       const promise = Promise.reject(expectedError)
 
-      return expect(applyActionSpinner('', promise)).to.be.rejectedWith(expectedError)
+      await expect(applyActionSpinner('', promise)).to.be.rejectedWith(expectedError)
     })
 
   test.stdout()
@@ -38,8 +38,8 @@ describe('applyActionSpinner', () => {
       const expectedError = new Error('error')
       const fakeMessage = 'my-terrible-message'
 
-      return expect(applyActionSpinner(fakeMessage, Promise.reject(expectedError))).to.be.rejected
-        .and.then(
-          expect(ctx.stderr).to.contain(fakeMessage))
+      await expect(applyActionSpinner(fakeMessage, Promise.reject(expectedError))).to.be.rejected
+
+      expect(ctx.stderr).to.contain(fakeMessage)
     })
 })

--- a/src/async-actions.test.ts
+++ b/src/async-actions.test.ts
@@ -1,6 +1,5 @@
-import {expect} from 'chai'
 import {applyActionSpinner} from './async-actions'
-import {test} from './test-utils'
+import {expect, test} from './test-utils'
 
 describe('applyActionSpinner', () => {
   test.stdout()
@@ -20,7 +19,7 @@ describe('applyActionSpinner', () => {
       const expectedError = new Error('my-bad-error')
       const promise = Promise.reject(expectedError)
 
-      expect(applyActionSpinner('', promise)).to.be.rejectedWith(expectedError)
+      return expect(applyActionSpinner('', promise)).to.be.rejectedWith(expectedError)
     })
 
   test.stdout()
@@ -36,10 +35,11 @@ describe('applyActionSpinner', () => {
   test.stdout()
     .stderr()
     .it('outputs the specified message for a failed execution', async ctx => {
+      const expectedError = new Error('error')
       const fakeMessage = 'my-terrible-message'
 
-      expect(applyActionSpinner(fakeMessage, Promise.reject(new Error('error')))).to.be.rejected
-
-      expect(ctx.stderr).to.contain(fakeMessage)
+      return expect(applyActionSpinner(fakeMessage, Promise.reject(expectedError))).to.be.rejected
+        .and.then(
+          expect(ctx.stderr).to.contain(fakeMessage))
     })
 })

--- a/src/command-components.test.ts
+++ b/src/command-components.test.ts
@@ -1,6 +1,6 @@
 import {AddOnAttachment} from '@heroku-cli/schema'
 import {expect} from 'fancy-test'
-import {anyString, instance, mock, verify} from 'ts-mockito'
+import {anyString, anything, instance, mock, verify, when} from 'ts-mockito'
 import {consoleColours, formatCliOptionName, processAddonAttachmentInfo} from './command-components'
 
 describe('formatCliOptionName', () => {
@@ -23,13 +23,14 @@ describe('processAddonAttachmentInfo', () => {
 
   beforeEach(() => {
     errorHandlerMockType = mock()
+    when(errorHandlerMockType.func(anything())).thenThrow(new Error('Invalid'))
     errorHandlerMockInstance = instance(errorHandlerMockType)
   })
 
   it('returns expected info when attachment is valid', () => {
     const fakeAttachment: AddOnAttachment = {
       addon: {app: {}, id: '6d0a1752-bfc5-4344-b998-155f90f0d550', name: fakeAddonName},
-      app: {name: fakeAppName},
+      app: {id: '4e7b43ba-b9b7-494d-9fda-f055e3ec7fcf', name: fakeAppName},
       id: '029d3d56-1c0d-4a7d-a76e-53d40b5ac649',
       name: fakeAddonAttachmentName,
     }
@@ -53,11 +54,8 @@ describe('processAddonAttachmentInfo', () => {
     }
     const expectedMessage = 'Add-on service is temporarily unavailable. Try again later.'
 
-    const result = processAddonAttachmentInfo(
-      fakeAttachments,
-      errorHandlerMockInstance.func)
-
-    expect(result).not.to.exist
+    expect(() => processAddonAttachmentInfo(fakeAttachments, errorHandlerMockInstance.func))
+      .to.throw()
 
     verify(errorHandlerMockType.func(expectedMessage)).once()
   })
@@ -70,11 +68,8 @@ describe('processAddonAttachmentInfo', () => {
     }
     const expectedMessage = 'Add-on service is temporarily unavailable. Try again later.'
 
-    const result = processAddonAttachmentInfo(
-      fakeAttachments,
-      errorHandlerMockInstance.func)
-
-    expect(result).not.to.exist
+    expect(() => processAddonAttachmentInfo(fakeAttachments, errorHandlerMockInstance.func))
+      .to.throw()
 
     verify(errorHandlerMockType.func(expectedMessage)).once()
   })
@@ -87,11 +82,8 @@ describe('processAddonAttachmentInfo', () => {
     }
     const expectedMessage = 'Add-on service is temporarily unavailable. Try again later.'
 
-    const result = processAddonAttachmentInfo(
-      fakeAttachments,
-      errorHandlerMockInstance.func)
-
-    expect(result).not.to.exist
+    expect(() => processAddonAttachmentInfo(fakeAttachments, errorHandlerMockInstance.func))
+      .to.throw()
 
     verify(errorHandlerMockType.func(expectedMessage)).once()
   })
@@ -105,11 +97,8 @@ describe('processAddonAttachmentInfo', () => {
     }
     const expectedMessage = 'Add-on service is temporarily unavailable. Try again later.'
 
-    const result = processAddonAttachmentInfo(
-      fakeAttachments,
-      errorHandlerMockInstance.func)
-
-    expect(result).not.to.exist
+    expect(() => processAddonAttachmentInfo(fakeAttachments, errorHandlerMockInstance.func))
+      .to.throw()
 
     verify(errorHandlerMockType.func(expectedMessage)).once()
   })

--- a/src/command-components.test.ts
+++ b/src/command-components.test.ts
@@ -1,4 +1,3 @@
-import color from '@heroku-cli/color'
 import {AddOnAttachment} from '@heroku-cli/schema'
 import {expect} from 'fancy-test'
 import {anyString, instance, mock, verify} from 'ts-mockito'
@@ -15,9 +14,9 @@ describe('formatCliOptionName', () => {
 })
 
 describe('processAddonAttachmentInfo', () => {
-  const fakeAddonAttachmentName = 'MY_NEAT_DB'
   const fakeAppName = 'my-neat-app'
   const fakeAddonName = 'my-neat-addon'
+  const fakeAddonAttachmentName = 'MY_NEAT_DB'
 
   let errorHandlerMockType: {func: ((message: string) => never)}
   let errorHandlerMockInstance: typeof errorHandlerMockType
@@ -27,24 +26,15 @@ describe('processAddonAttachmentInfo', () => {
     errorHandlerMockInstance = instance(errorHandlerMockType)
   })
 
-  it('returns the first entry when there are multiple', () => {
-    const fakeAttachments: AddOnAttachment[] = [
-      {
-        addon: {app: {}, id: '#1', name: fakeAddonName},
-        app: {name: fakeAppName},
-        name: fakeAddonAttachmentName,
-      },
-      {
-        addon: {app: {}, id: '#2', name: 'another-addon'},
-        app: {name: 'another-app'},
-        name: 'another-attachment',
-      },
-    ]
+  it('returns expected info when attachment is valid', () => {
+    const fakeAttachment: AddOnAttachment = {
+      addon: {app: {}, id: '6d0a1752-bfc5-4344-b998-155f90f0d550', name: fakeAddonName},
+      app: {name: fakeAppName},
+      id: '029d3d56-1c0d-4a7d-a76e-53d40b5ac649',
+      name: fakeAddonAttachmentName,
+    }
 
-    const result = processAddonAttachmentInfo(
-      fakeAttachments,
-      {addonOrAttachment: fakeAddonName},
-      errorHandlerMockInstance.func)
+    const result = processAddonAttachmentInfo(fakeAttachment, errorHandlerMockInstance.func)
 
     expect(result).to.deep.equal({
       addonName: fakeAddonName,
@@ -55,52 +45,16 @@ describe('processAddonAttachmentInfo', () => {
     verify(errorHandlerMockType.func(anyString())).never()
   })
 
-  it('returns the first entry when there is only one', () => {
-    const fakeAttachments: AddOnAttachment[] = [
-      {
-        addon: {app: {}, id: '#1', name: fakeAddonName},
-        app: {name: fakeAppName},
-        name: fakeAddonAttachmentName,
-      },
-    ]
+  it('indicates an error when the attachment does not have an attachment name field', () => {
+    const fakeAttachments: AddOnAttachment = {
+      addon: {app: {}, id: 'ad7f474c-4b7d-4f12-abc8-ad7ce918da7b', name: fakeAddonName},
+      app: {id: 'f0815480-3a36-4a00-a821-958951bca22f', name: fakeAppName},
+      id: '6ef02958-4017-433c-8745-7b80fcd44578',
+    }
+    const expectedMessage = 'Add-on service is temporarily unavailable. Try again later.'
 
     const result = processAddonAttachmentInfo(
       fakeAttachments,
-      {addonOrAttachment: fakeAddonAttachmentName, app: fakeAppName},
-      errorHandlerMockInstance.func)
-
-    expect(result).to.deep.equal({
-      addonName: fakeAddonName,
-      appName: fakeAppName,
-      attachmentName: fakeAddonAttachmentName,
-    })
-
-    verify(errorHandlerMockType.func(anyString())).never()
-  })
-
-  it('indicates when the attachment does not belong to the app', () => {
-    const expectedMessage =
-      `App ${color.app(fakeAppName)} has no ${color.addon(fakeAddonAttachmentName)} add-on ` +
-      'attachment'
-
-    const result = processAddonAttachmentInfo(
-      null,
-      {addonOrAttachment: fakeAddonAttachmentName, app: fakeAppName},
-      errorHandlerMockInstance.func)
-
-    expect(result).not.to.exist
-
-    verify(errorHandlerMockType.func(expectedMessage)).once()
-  })
-
-  it('indicates when the add-on name does not correspond to an add-on', () => {
-    const expectedMessage =
-      `Add-on ${color.addon(fakeAddonName)} was not found. Consider trying again with the ` +
-      `${consoleColours.cliOption('--app')} option.`
-
-    const result = processAddonAttachmentInfo(
-      null,
-      {addonOrAttachment: fakeAddonName},
       errorHandlerMockInstance.func)
 
     expect(result).not.to.exist
@@ -109,12 +63,15 @@ describe('processAddonAttachmentInfo', () => {
   })
 
   it('indicates an error when the attachment does not have an addon field', () => {
-    const fakeAttachments: AddOnAttachment[] = [{id: fakeAddonAttachmentName}]
+    const fakeAttachments: AddOnAttachment = {
+      app: {id: '924d8a7e-fa07-4011-b1fa-81174a57e32a', name: fakeAppName},
+      id: '4d66b508-dda8-4055-97b3-bc96569e564c',
+      name: fakeAddonAttachmentName,
+    }
     const expectedMessage = 'Add-on service is temporarily unavailable. Try again later.'
 
     const result = processAddonAttachmentInfo(
       fakeAttachments,
-      {addonOrAttachment: fakeAddonAttachmentName, app: fakeAppName},
       errorHandlerMockInstance.func)
 
     expect(result).not.to.exist
@@ -122,16 +79,38 @@ describe('processAddonAttachmentInfo', () => {
     verify(errorHandlerMockType.func(expectedMessage)).once()
   })
 
-  it('indicates an error when the attachment list is empty', () => {
-    const fakeAttachments: AddOnAttachment[] = []
+  it('indicates an error when the attachment does not have an app field', () => {
+    const fakeAttachments: AddOnAttachment = {
+      addon: {app: {}, id: '03ae7f18-a7d8-442e-ac4b-ed6578f54d0f', name: fakeAddonName},
+      id: 'a593fea2-6a9e-4c28-9b70-78654dee8349',
+      name: fakeAddonAttachmentName,
+    }
+    const expectedMessage = 'Add-on service is temporarily unavailable. Try again later.'
 
     const result = processAddonAttachmentInfo(
       fakeAttachments,
-      {addonOrAttachment: fakeAddonName},
       errorHandlerMockInstance.func)
 
     expect(result).not.to.exist
 
-    verify(errorHandlerMockType.func(anyString())).once()
+    verify(errorHandlerMockType.func(expectedMessage)).once()
+  })
+
+  it('indicates an error when the attachment does not have an app name field', () => {
+    const fakeAttachments: AddOnAttachment = {
+      addon: {app: {}, id: 'fdf7f80d-cb9e-4719-95fb-d9bda9aabc9c', name: fakeAddonName},
+      app: {id: 'e9539aad-e026-4925-8eb8-ce88d31e477a'},
+      id: '601d07fd-02ff-484a-acb2-fcd0e4bc3d56',
+      name: fakeAddonAttachmentName,
+    }
+    const expectedMessage = 'Add-on service is temporarily unavailable. Try again later.'
+
+    const result = processAddonAttachmentInfo(
+      fakeAttachments,
+      errorHandlerMockInstance.func)
+
+    expect(result).not.to.exist
+
+    verify(errorHandlerMockType.func(expectedMessage)).once()
   })
 })

--- a/src/command-components.ts
+++ b/src/command-components.ts
@@ -29,7 +29,6 @@ export const cliOptions = {
   addon: flags.string({
     char: 'o',
     description: 'name or ID of an add-on or one of its attachments',
-    required: true,
   }),
   app: flags.app({
     description: 'app to which the add-on is attached',
@@ -74,40 +73,26 @@ export function formatCliOptionName(name: string): string {
 }
 
 /**
- * Retrieves various add-on info for the first entry in the given attachment info list
+ * Retrieves vital add-on info from the given attachment info
  *
- * @param attachmentInfos A list of attachment information
- * @param addonFilter The filter that was used to fetch the attachment info list
+ * @param attachmentInfo A list of attachment information
  * @param errorHandler A function to output errors when they occur
  *
  * @returns Info about the corresponding add-on
  */
 export function processAddonAttachmentInfo(
-  attachmentInfos: AddOnAttachment[] | null,
-  addonFilter: {addonOrAttachment: string; app?: string},
+  attachmentInfo: AddOnAttachment,
   errorHandler: (message: string) => never): {
     addonName: string;
     appName: string;
     attachmentName: string;
   } | never {
-  if (attachmentInfos && attachmentInfos.length > 0) {
-    const [attachmentInfo] = attachmentInfos
-
-    const addonName = attachmentInfo.addon?.name
-    const appName = attachmentInfo.app?.name
-    const attachmentName = attachmentInfo.name
-    if (addonName && appName && attachmentName) {
-      return {addonName, appName, attachmentName}
-    } else {
-      errorHandler('Add-on service is temporarily unavailable. Try again later.')
-    }
-  } else if (addonFilter.app) {
-    return errorHandler(
-      `App ${color.app(addonFilter.app)} has no ${color.addon(addonFilter.addonOrAttachment)} ` +
-      'add-on attachment')
+  const addonName = attachmentInfo.addon?.name
+  const appName = attachmentInfo.app?.name
+  const attachmentName = attachmentInfo.name
+  if (addonName && appName && attachmentName) {
+    return {addonName, appName, attachmentName}
   } else {
-    return errorHandler(
-      `Add-on ${color.addon(addonFilter.addonOrAttachment)} was not found. Consider trying again ` +
-      `with the ${formatCliOptionName(appOptionName)} option.`)
+    errorHandler('Add-on service is temporarily unavailable. Try again later.')
   }
 }

--- a/src/commands/borealis-pg/extensions/index.test.ts
+++ b/src/commands/borealis-pg/extensions/index.test.ts
@@ -1,19 +1,26 @@
-import color from '@heroku-cli/color'
 import {borealisPgApiBaseUrl, expect, herokuApiBaseUrl, test} from '../../../test-utils'
 
+const fakeAddonId = '0818035e-0103-4f85-880d-c3b4a712cf8d'
 const fakeAddonName = 'borealis-pg-my-fake-addon'
-const fakeAddonAttachmentName = 'MY_COOL_DB'
+
+const fakeAttachmentId = 'eaa7f0f9-9562-4ba3-b8dc-3c488ad73666'
+const fakeAttachmentName = 'MY_COOL_DB'
+
+const fakeHerokuAppId = '2ee2aea8-9a2f-48b2-8f86-b4aa504b35f7'
 const fakeHerokuAppName = 'my-fake-heroku-app'
+
 const fakeHerokuAuthToken = 'my-fake-heroku-auth-token'
 const fakeHerokuAuthId = 'my-fake-heroku-auth'
+
 const fakeExt1 = 'my-first-fake-pg-extension'
 const fakeExt1Schema = 'my-first-fake-db-schema'
 const fakeExt1Version = '16.8.5'
+
 const fakeExt2 = 'my-second-fake-pg-extension'
 const fakeExt2Schema = 'my-second-fake-db-schema'
 const fakeExt2Version = '0.7.15'
 
-const baseTestContext = test.stdout()
+const defaultTestContext = test.stdout()
   .stderr()
   .nock(herokuApiBaseUrl, api => api
     .post('/oauth/authorizations', {
@@ -23,27 +30,21 @@ const baseTestContext = test.stdout()
     })
     .reply(201, {id: fakeHerokuAuthId, access_token: {token: fakeHerokuAuthToken}})
     .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
-    .reply(200))
-
-const testContextWithoutAppOption = baseTestContext
-  .nock(herokuApiBaseUrl, api => api
+    .reply(200)
     .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
     .reply(200, [
-      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: fakeAddonAttachmentName},
-      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
-    ]))
-
-const testContextWithAppOption = baseTestContext
-  .nock(herokuApiBaseUrl, api => api
-    .post(
-      '/actions/addon-attachments/resolve',
-      {addon_attachment: fakeAddonAttachmentName, app: fakeHerokuAppName})
-    .reply(200, [
-      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: fakeAddonAttachmentName},
-    ]))
+      {
+        addon: {id: fakeAddonId, name: fakeAddonName},
+        app: {id: fakeHerokuAppId, name: fakeHerokuAppName},
+        id: fakeAttachmentId,
+        name: fakeAttachmentName,
+      },
+    ])
+    .get(`/addons/${fakeAddonId}`)
+    .reply(200, {addon_service: {name: 'borealis-pg'}, id: fakeAddonId, name: fakeAddonName}))
 
 describe('extension list command', () => {
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -55,7 +56,7 @@ describe('extension list command', () => {
           ],
         }))
     .command(['borealis-pg:extensions', '--addon', fakeAddonName])
-    .it('outputs the list of installed extensions when given only an add-on name', ctx => {
+    .it('outputs the list of installed extensions', ctx => {
       expect(ctx.stderr).to.endWith(
         `Fetching Postgres extension list for add-on ${fakeAddonName}... done\n`)
       expect(ctx.stdout).to.equal(
@@ -63,35 +64,7 @@ describe('extension list command', () => {
         `- ${fakeExt2} (version: ${fakeExt2Version}, schema: ${fakeExt2Schema})\n`)
     })
 
-  testContextWithAppOption
-    .nock(
-      borealisPgApiBaseUrl,
-      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
-      api => api.get(`/heroku/resources/${fakeAddonName}/pg-extensions`)
-        .reply(200, {
-          extensions: [
-            {name: fakeExt2, schema: fakeExt2Schema, version: fakeExt2Version},
-            {name: fakeExt1, schema: fakeExt1Schema, version: fakeExt1Version},
-          ],
-        }))
-    .command([
-      'borealis-pg:extensions',
-      '--addon',
-      fakeAddonAttachmentName,
-      '--app',
-      fakeHerokuAppName,
-    ])
-    .it(
-      'outputs the list of installed extensions when given add-on attachment and app names',
-      ctx => {
-        expect(ctx.stderr).to.endWith(
-          `Fetching Postgres extension list for add-on ${fakeAddonName}... done\n`)
-        expect(ctx.stdout).to.equal(
-          `- ${fakeExt2} (version: ${fakeExt2Version}, schema: ${fakeExt2Schema})\n` +
-          `- ${fakeExt1} (version: ${fakeExt1Version}, schema: ${fakeExt1Schema})\n`)
-      })
-
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api.get(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -104,29 +77,29 @@ describe('extension list command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api.get(`/heroku/resources/${fakeAddonName}/pg-extensions`)
         .reply(404, {reason: 'Does not exist'}))
     .command(['borealis-pg:extensions', '-o', fakeAddonName])
-    .catch(`Add-on ${color.addon(fakeAddonName)} is not a Borealis Isolated Postgres add-on`)
+    .catch('Add-on is not a Borealis Isolated Postgres add-on')
     .it('exits with an error if the add-on was not found', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api.get(`/heroku/resources/${fakeAddonName}/pg-extensions`)
         .reply(422, {reason: 'Not ready yet'}))
     .command(['borealis-pg:extensions', '-o', fakeAddonName])
-    .catch(`Add-on ${color.addon(fakeAddonName)} is not finished provisioning`)
+    .catch('Add-on is not finished provisioning')
     .it('exits with an error if the add-on is not done provisioning', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api.get(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -139,32 +112,9 @@ describe('extension list command', () => {
 
   test.stdout()
     .stderr()
-    .nock(
-      herokuApiBaseUrl,
-      api => api
-        .post('/oauth/authorizations')
-        .reply(201, {id: fakeHerokuAuthId})  // Note that the access_token field is missing
-        .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
-        .reply(200)
-        .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
-        .reply(200, [
-          {
-            addon: {name: fakeAddonName},
-            app: {name: fakeHerokuAppName},
-            name: fakeAddonAttachmentName,
-          },
-        ]))
-    .command(['borealis-pg:extensions', '-o', fakeAddonName])
-    .catch('Log in to the Heroku CLI first!')
-    .it('exits with an error if there is no Heroku access token', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
-
-  test.stdout()
-    .stderr()
     .command(['borealis-pg:extensions'])
-    .catch(/^Missing required flag:/)
-    .it('exits with an error if there is no add-on name option', ctx => {
+    .catch(/^Borealis Isolated Postgres add-on could not be found/)
+    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 })

--- a/src/commands/borealis-pg/extensions/index.test.ts
+++ b/src/commands/borealis-pg/extensions/index.test.ts
@@ -109,12 +109,4 @@ describe('extension list command', () => {
     .it('exits with an error if the Borealis PG API indicates a server error', ctx => {
       expect(ctx.stdout).to.equal('')
     })
-
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:extensions'])
-    .catch(/^Borealis Isolated Postgres add-on could not be found/)
-    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
 })

--- a/src/commands/borealis-pg/extensions/index.ts
+++ b/src/commands/borealis-pg/extensions/index.ts
@@ -26,11 +26,9 @@ export default class ListPgExtensionsCommand extends Command {
   async run() {
     const {flags} = this.parse(ListPgExtensionsCommand)
     const authorization = await createHerokuAuth(this.heroku)
-    const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const {addonName} = processAddonAttachmentInfo(
-      attachmentInfos,
-      {addonOrAttachment: flags.addon, app: flags.app},
-      this.error)
+    const attachmentInfo =
+      await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app, this.error)
+    const {addonName} = processAddonAttachmentInfo(attachmentInfo, this.error)
     try {
       const response = await applyActionSpinner(
         `Fetching Postgres extension list for add-on ${color.addon(addonName)}`,
@@ -57,13 +55,11 @@ export default class ListPgExtensionsCommand extends Command {
   }
 
   async catch(err: any) {
-    const {flags} = this.parse(ListPgExtensionsCommand)
-
     if (err instanceof HTTPError) {
       if (err.statusCode === 404) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
+        this.error('Add-on is not a Borealis Isolated Postgres add-on')
       } else if (err.statusCode === 422) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)
+        this.error('Add-on is not finished provisioning')
       } else {
         this.error('Add-on service is temporarily unavailable. Try again later.')
       }

--- a/src/commands/borealis-pg/extensions/index.ts
+++ b/src/commands/borealis-pg/extensions/index.ts
@@ -55,6 +55,7 @@ export default class ListPgExtensionsCommand extends Command {
   }
 
   async catch(err: any) {
+    /* istanbul ignore else */
     if (err instanceof HTTPError) {
       if (err.statusCode === 404) {
         this.error('Add-on is not a Borealis Isolated Postgres add-on')

--- a/src/commands/borealis-pg/extensions/install.test.ts
+++ b/src/commands/borealis-pg/extensions/install.test.ts
@@ -277,12 +277,4 @@ describe('extension installation command', () => {
     .it('exits with an error if there is no Postgres extension argument', ctx => {
       expect(ctx.stdout).to.equal('')
     })
-
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:extensions:install', fakeExt1])
-    .catch(/^Borealis Isolated Postgres add-on could not be found/)
-    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
 })

--- a/src/commands/borealis-pg/extensions/install.test.ts
+++ b/src/commands/borealis-pg/extensions/install.test.ts
@@ -1,23 +1,33 @@
 import color from '@heroku-cli/color'
 import {borealisPgApiBaseUrl, expect, herokuApiBaseUrl, test} from '../../../test-utils'
 
+const fakeAddonId = 'bde71749-e560-42d7-b9ab-ccb6d91b17b5'
 const fakeAddonName = 'borealis-pg-my-fake-addon'
-const fakeAddonAttachmentName = 'MY_COOL_DB'
+
+const fakeAttachmentId = '8c76b180-afb4-41fe-8f8d-79bfc8d0e3fa'
+const fakeAttachmentName = 'MY_COOL_DB'
+
+const fakeHerokuAppId = 'a9faf548-3d67-4507-8f3a-8384af204ef0'
 const fakeHerokuAppName = 'my-fake-heroku-app'
+
 const fakeHerokuAuthToken = 'my-fake-heroku-auth-token'
 const fakeHerokuAuthId = 'my-fake-heroku-auth'
+
 const fakeExt1 = 'my-first-fake-pg-extension'
 const fakeExt1Schema = 'my-first-fake-pg-ext-schema'
 const fakeExt1Version = '1.11.111'
+
 const fakeExt2 = 'my-second-fake-pg-extension'
 const fakeExt2Schema = 'my-second-fake-pg-ext-schema'
 const fakeExt2Version = '22.2.0'
+
 const fakeExt3 = 'my-third-fake-pg-extension'
 const fakeExt3Schema = 'my-third-fake-pg-ext-schema'
 const fakeExt3Version = '3.3'
+
 const pgExtensionColour = color.green
 
-const baseTestContext = test.stdout()
+const defaultTestContext = test.stdout()
   .stderr()
   .nock(
     herokuApiBaseUrl,
@@ -29,27 +39,21 @@ const baseTestContext = test.stdout()
       })
       .reply(201, {id: fakeHerokuAuthId, access_token: {token: fakeHerokuAuthToken}})
       .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
-      .reply(200))
-
-const testContextWithoutAppOption = baseTestContext
-  .nock(herokuApiBaseUrl, api => api
-    .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
-    .reply(200, [
-      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: fakeAddonAttachmentName},
-      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
-    ]))
-
-const testContextWithAppOption = baseTestContext
-  .nock(herokuApiBaseUrl, api => api
-    .post(
-      '/actions/addon-attachments/resolve',
-      {addon_attachment: fakeAddonAttachmentName, app: fakeHerokuAppName})
-    .reply(200, [
-      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: fakeAddonAttachmentName},
-    ]))
+      .reply(200)
+      .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
+      .reply(200, [
+        {
+          addon: {id: fakeAddonId, name: fakeAddonName},
+          app: {id: fakeHerokuAppId, name: fakeHerokuAppName},
+          id: fakeAttachmentId,
+          name: fakeAttachmentName,
+        },
+      ])
+      .get(`/addons/${fakeAddonId}`)
+      .reply(200, {addon_service: {name: 'borealis-pg'}, id: fakeAddonId, name: fakeAddonName}))
 
 describe('extension installation command', () => {
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -59,38 +63,14 @@ describe('extension installation command', () => {
           {pgExtensionName: fakeExt1})
         .reply(201, {pgExtensionSchema: fakeExt1Schema, pgExtensionVersion: fakeExt1Version}))
     .command(['borealis-pg:extensions:install', '--addon', fakeAddonName, fakeExt1])
-    .it('installs the requested extension when given only an add-on name', ctx => {
+    .it('installs the requested extension', ctx => {
       expect(ctx.stderr).to.endWith(
         `Installing Postgres extension ${fakeExt1} for add-on ${fakeAddonName}... done\n`)
       expect(ctx.stdout).to.equal(
         `- ${fakeExt1} (version: ${fakeExt1Version}, schema: ${fakeExt1Schema})\n`)
     })
 
-  testContextWithAppOption
-    .nock(
-      borealisPgApiBaseUrl,
-      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
-      api => api
-        .post(
-          `/heroku/resources/${fakeAddonName}/pg-extensions`,
-          {pgExtensionName: fakeExt2})
-        .reply(201, {pgExtensionSchema: fakeExt2Schema, pgExtensionVersion: fakeExt2Version}))
-    .command([
-      'borealis-pg:extensions:install',
-      '-o',
-      fakeAddonAttachmentName,
-      '-a',
-      fakeHerokuAppName,
-      fakeExt2,
-    ])
-    .it('installs the requested extension when given add-on attachment and app names', ctx => {
-      expect(ctx.stderr).to.endWith(
-        `Installing Postgres extension ${fakeExt2} for add-on ${fakeAddonName}... done\n`)
-      expect(ctx.stdout).to.equal(
-        `- ${fakeExt2} (version: ${fakeExt2Version}, schema: ${fakeExt2Schema})\n`)
-    })
-
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
@@ -115,30 +95,39 @@ describe('extension installation command', () => {
         expect(ctx.stdout).to.equal('')
       })
 
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
-          {pgExtensionName: fakeExt3})
+          {pgExtensionName: fakeExt1})
         .reply(400, {reason: 'Missing dependencies', dependencies: [fakeExt2]})
+        .post(
+          `/heroku/resources/${fakeAddonName}/pg-extensions`,
+          {pgExtensionName: fakeExt2})
+        .reply(400, {reason: 'Missing dependencies', dependencies: [fakeExt3]})
+        .post(
+          `/heroku/resources/${fakeAddonName}/pg-extensions`,
+          {pgExtensionName: fakeExt3})
+        .reply(201, {pgExtensionSchema: fakeExt3Schema, pgExtensionVersion: fakeExt3Version})
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
           {pgExtensionName: fakeExt2})
         .reply(201, {pgExtensionSchema: fakeExt2Schema, pgExtensionVersion: fakeExt2Version})
         .post(
           `/heroku/resources/${fakeAddonName}/pg-extensions`,
-          {pgExtensionName: fakeExt3})
-        .reply(201, {pgExtensionSchema: fakeExt3Schema, pgExtensionVersion: fakeExt3Version}))
-    .command(['borealis-pg:extensions:install', '-r', '-o', fakeAddonName, fakeExt3])
-    .it('installs the extension and its dependencies when given only an add-on name', ctx => {
+          {pgExtensionName: fakeExt1})
+        .reply(201, {pgExtensionSchema: fakeExt1Schema, pgExtensionVersion: fakeExt1Version}))
+    .command(['borealis-pg:extensions:install', '-r', '-o', fakeAddonName, fakeExt1])
+    .it('recursively installs the extension and its dependencies', ctx => {
       expect(ctx.stdout).to.equal(
-        `- ${fakeExt3} (version: ${fakeExt3Version}, schema: ${fakeExt3Schema})\n` +
-        `- ${fakeExt2} (version: ${fakeExt2Version}, schema: ${fakeExt2Schema})\n`)
+        `- ${fakeExt1} (version: ${fakeExt1Version}, schema: ${fakeExt1Schema})\n` +
+        `- ${fakeExt2} (version: ${fakeExt2Version}, schema: ${fakeExt2Schema})\n` +
+        `- ${fakeExt3} (version: ${fakeExt3Version}, schema: ${fakeExt3Schema})\n`)
     })
 
-  testContextWithAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api
@@ -162,52 +151,18 @@ describe('extension installation command', () => {
       'borealis-pg:extensions:install',
       '--recursive',
       '--addon',
-      fakeAddonAttachmentName,
-      '--app',
-      fakeHerokuAppName,
+      fakeAddonName,
       fakeExt1,
     ])
     .it(
-      'installs the extension and its dependencies when given add-on attachment and app names',
+      'recursively installs the extension and its dependencies when one is already installed',
       ctx => {
         expect(ctx.stdout).to.equal(
           `- ${fakeExt1} (version: ${fakeExt1Version}, schema: ${fakeExt1Schema})\n` +
           `- ${fakeExt3} (version: ${fakeExt3Version}, schema: ${fakeExt3Schema})\n`)
       })
 
-  testContextWithoutAppOption
-    .nock(
-      borealisPgApiBaseUrl,
-      api => api
-        .post(
-          `/heroku/resources/${fakeAddonName}/pg-extensions`,
-          {pgExtensionName: fakeExt1})
-        .reply(400, {reason: 'Missing dependencies', dependencies: [fakeExt2]})
-        .post(
-          `/heroku/resources/${fakeAddonName}/pg-extensions`,
-          {pgExtensionName: fakeExt2})
-        .reply(400, {reason: 'Missing dependencies', dependencies: [fakeExt3]})
-        .post(
-          `/heroku/resources/${fakeAddonName}/pg-extensions`,
-          {pgExtensionName: fakeExt3})
-        .reply(201, {pgExtensionSchema: fakeExt3Schema, pgExtensionVersion: fakeExt3Version})
-        .post(
-          `/heroku/resources/${fakeAddonName}/pg-extensions`,
-          {pgExtensionName: fakeExt2})
-        .reply(201, {pgExtensionSchema: fakeExt2Schema, pgExtensionVersion: fakeExt2Version})
-        .post(
-          `/heroku/resources/${fakeAddonName}/pg-extensions`,
-          {pgExtensionName: fakeExt1})
-        .reply(201, {pgExtensionSchema: fakeExt1Schema, pgExtensionVersion: fakeExt1Version}))
-    .command(['borealis-pg:extensions:install', '-r', '-o', fakeAddonName, fakeExt1])
-    .it('installs the extension and its dependencies recursively', ctx => {
-      expect(ctx.stdout).to.equal(
-        `- ${fakeExt1} (version: ${fakeExt1Version}, schema: ${fakeExt1Schema})\n` +
-        `- ${fakeExt2} (version: ${fakeExt2Version}, schema: ${fakeExt2Schema})\n` +
-        `- ${fakeExt3} (version: ${fakeExt3Version}, schema: ${fakeExt3Schema})\n`)
-    })
-
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api
@@ -229,7 +184,7 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -242,7 +197,7 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api
@@ -260,7 +215,7 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -271,18 +226,18 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
         .reply(404, {reason: 'Add-on does not exist'}))
     .command(['borealis-pg:extensions:install', '-o', fakeAddonName, fakeExt2])
-    .catch(`Add-on ${color.addon(fakeAddonName)} is not a Borealis Isolated Postgres add-on`)
+    .catch('Add-on is not a Borealis Isolated Postgres add-on')
     .it('exits with an error if the add-on was not found', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -293,18 +248,18 @@ describe('extension installation command', () => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
         .reply(422, {reason: 'Not ready yet'}))
     .command(['borealis-pg:extensions:install', '-o', fakeAddonName, fakeExt2])
-    .catch(`Add-on ${color.addon(fakeAddonName)} is not finished provisioning`)
+    .catch('Add-on is not finished provisioning')
     .it('exits with an error if the add-on is not fully provisioned', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 
-  testContextWithoutAppOption
+  defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
       api => api.post(`/heroku/resources/${fakeAddonName}/pg-extensions`)
@@ -317,39 +272,17 @@ describe('extension installation command', () => {
 
   test.stdout()
     .stderr()
-    .nock(
-      herokuApiBaseUrl,
-      api => api.post('/oauth/authorizations')
-        .reply(201, {id: fakeHerokuAuthId})  // The access_token field is missing
-        .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
-        .reply(200)
-        .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
-        .reply(200, [
-          {
-            addon: {name: fakeAddonName},
-            app: {name: fakeHerokuAppName},
-            name: fakeAddonAttachmentName,
-          },
-        ]))
-    .command(['borealis-pg:extensions:install', '-o', fakeAddonName, fakeExt2])
-    .catch('Log in to the Heroku CLI first!')
-    .it('exits with an error if there is no Heroku access token', ctx => {
+    .command(['borealis-pg:extensions:install', '-o', fakeAddonName])
+    .catch(/^Missing 1 required arg:/)
+    .it('exits with an error if there is no Postgres extension argument', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 
   test.stdout()
     .stderr()
     .command(['borealis-pg:extensions:install', fakeExt1])
-    .catch(/^Missing required flag:/)
-    .it('exits with an error if there is no add-on name option', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
-
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:extensions:install', '-o', fakeAddonName])
-    .catch(/^Missing 1 required arg:/)
-    .it('exits with an error if there is no Postgres extension argument', ctx => {
+    .catch(/^Borealis Isolated Postgres add-on could not be found/)
+    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 })

--- a/src/commands/borealis-pg/extensions/install.ts
+++ b/src/commands/borealis-pg/extensions/install.ts
@@ -155,6 +155,7 @@ https://www.borealis-data.com/pg-extensions-support.html`
     const {args} = this.parse(InstallPgExtensionsCommand)
     const pgExtension = args[cliArgs.pgExtension.name]
 
+    /* istanbul ignore else */
     if (err instanceof HTTPError) {
       if (err.statusCode === 400) {
         if (err.body.dependencies) {

--- a/src/commands/borealis-pg/extensions/install.ts
+++ b/src/commands/borealis-pg/extensions/install.ts
@@ -22,7 +22,8 @@ const recursiveOptionName = 'recursive'
 const suppressConflictOptionName = 'suppress-conflict'
 
 export default class InstallPgExtensionsCommand extends Command {
-  static description = `installs a Postgres extension on a Borealis Isolated Postgres add-on
+  static description =
+    `installs a Postgres extension on a Borealis Isolated Postgres add-on database
 
 Each extension is typically installed with its own dedicated database schema,
 which may be used to store types, functions, tables or other objects that are
@@ -33,6 +34,12 @@ installed automatically only if the ${formatCliOptionName(recursiveOptionName)} 
 
 Details of all supported extensions can be found here:
 https://www.borealis-data.com/pg-extensions-support.html`
+
+static examples = [
+  `$ heroku borealis-pg:extensions:install --${recursiveOptionName} --${appOptionName} sushi hstore_plperl`,
+  `$ heroku borealis-pg:extensions:install --${appOptionName} sushi --${addonOptionName} BOREALIS_PG_MAROON bloom`,
+  `$ heroku borealis-pg:extensions:install --${suppressConflictOptionName} --${addonOptionName} borealis-pg-hex-12345 pg_trgm`,
+]
 
   static args = [
     cliArgs.pgExtension,

--- a/src/commands/borealis-pg/extensions/install.ts
+++ b/src/commands/borealis-pg/extensions/install.ts
@@ -58,11 +58,9 @@ https://www.borealis-data.com/pg-extensions-support.html`
     const pgExtension = args[cliArgs.pgExtension.name]
     const suppressConflict = flags[suppressConflictOptionName]
     const authorization = await createHerokuAuth(this.heroku)
-    const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const {addonName} = processAddonAttachmentInfo(
-      attachmentInfos,
-      {addonOrAttachment: flags.addon, app: flags.app},
-      this.error)
+    const attachmentInfo =
+      await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app, this.error)
+    const {addonName} = processAddonAttachmentInfo(attachmentInfo, this.error)
 
     try {
       const extInfos = await applyActionSpinner(
@@ -154,7 +152,7 @@ https://www.borealis-data.com/pg-extensions-support.html`
   }
 
   async catch(err: any) {
-    const {args, flags} = this.parse(InstallPgExtensionsCommand)
+    const {args} = this.parse(InstallPgExtensionsCommand)
     const pgExtension = args[cliArgs.pgExtension.name]
 
     if (err instanceof HTTPError) {
@@ -173,11 +171,11 @@ https://www.borealis-data.com/pg-extensions-support.html`
           this.error(`${pgExtensionColour(pgExtension)} is not a supported Postgres extension`)
         }
       } else if (err.statusCode === 404) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
+        this.error('Add-on is not a Borealis Isolated Postgres add-on')
       } else if (err.statusCode === 409) {
         this.error(getAlreadyInstalledMessage(pgExtension))
       } else if (err.statusCode === 422) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)
+        this.error('Add-on is not finished provisioning')
       } else {
         this.error('Add-on service is temporarily unavailable. Try again later.')
       }

--- a/src/commands/borealis-pg/extensions/remove.test.ts
+++ b/src/commands/borealis-pg/extensions/remove.test.ts
@@ -221,12 +221,4 @@ describe('extension removal command', () => {
     .it('exits with an error if there is no Postgres extension argument', ctx => {
       expect(ctx.stdout).to.equal('')
     })
-
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:extensions:remove', '-c', fakeExt2, fakeExt2])
-    .catch(/^Borealis Isolated Postgres add-on could not be found/)
-    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
 })

--- a/src/commands/borealis-pg/extensions/remove.ts
+++ b/src/commands/borealis-pg/extensions/remove.ts
@@ -86,6 +86,7 @@ export default class RemovePgExtensionCommand extends Command {
     const {args} = this.parse(RemovePgExtensionCommand)
     const pgExtension = args[cliArgs.pgExtension.name]
 
+    /* istanbul ignore else */
     if (err instanceof HTTPError) {
       if (err.statusCode === 400) {
         this.error(

--- a/src/commands/borealis-pg/extensions/remove.ts
+++ b/src/commands/borealis-pg/extensions/remove.ts
@@ -22,7 +22,14 @@ const suppressMissingOptionName = 'suppress-missing'
 const addonResourceType = 'addon'
 
 export default class RemovePgExtensionCommand extends Command {
-  static description = 'removes a Postgres extension from a Borealis Isolated Postgres add-on'
+  static description =
+    'removes a Postgres extension from a Borealis Isolated Postgres add-on database'
+
+  static examples = [
+    `$ heroku borealis-pg:extensions:remove --${suppressMissingOptionName} --${appOptionName} sushi postgis`,
+    `$ heroku borealis-pg:extensions:remove --${appOptionName} sushi --${addonOptionName} BOREALIS_PG_MAROON btree_gist`,
+    `$ heroku borealis-pg:extensions:remove --${confirmOptionName} uuid-ossp --${addonOptionName} borealis-pg-hex-12345 uuid-ossp`,
+  ]
 
   static args = [
     cliArgs.pgExtension,

--- a/src/commands/borealis-pg/info.test.ts
+++ b/src/commands/borealis-pg/info.test.ts
@@ -329,12 +329,4 @@ describe('add-on info command', () => {
     .it('exits with an error when there is an API server error', ctx => {
       expect(ctx.stdout).to.equal('')
     })
-
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:info'])
-    .catch(/^Borealis Isolated Postgres add-on could not be found/)
-    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
 })

--- a/src/commands/borealis-pg/info.ts
+++ b/src/commands/borealis-pg/info.ts
@@ -107,6 +107,7 @@ export default class AddonInfoCommand extends Command {
   }
 
   async catch(err: any) {
+    /* istanbul ignore else */
     if (err instanceof HTTPError) {
       if (err.statusCode === 404) {
         this.error('Add-on is not a Borealis Isolated Postgres add-on')

--- a/src/commands/borealis-pg/info.ts
+++ b/src/commands/borealis-pg/info.ts
@@ -3,7 +3,13 @@ import {Command} from '@heroku-cli/command'
 import {HTTP, HTTPError} from 'http-call'
 import {applyActionSpinner} from '../../async-actions'
 import {getBorealisPgApiUrl, getBorealisPgAuthHeader} from '../../borealis-api'
-import {addonOptionName, cliOptions, appOptionName, processAddonAttachmentInfo, consoleColours} from '../../command-components'
+import {
+  addonOptionName,
+  cliOptions,
+  appOptionName,
+  processAddonAttachmentInfo,
+  consoleColours,
+} from '../../command-components'
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from '../../heroku-api'
 
 const keyColour = consoleColours.dataFieldName
@@ -43,11 +49,9 @@ export default class AddonInfoCommand extends Command {
   async run() {
     const {flags} = this.parse(AddonInfoCommand)
     const authorization = await createHerokuAuth(this.heroku)
-    const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const {addonName} = processAddonAttachmentInfo(
-      attachmentInfos,
-      {addonOrAttachment: flags.addon, app: flags.app},
-      this.error)
+    const attachmentInfo =
+      await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app, this.error)
+    const {addonName} = processAddonAttachmentInfo(attachmentInfo, this.error)
 
     try {
       const response = await applyActionSpinner<HTTP<AddonInfo>>(
@@ -103,11 +107,9 @@ export default class AddonInfoCommand extends Command {
   }
 
   async catch(err: any) {
-    const {flags} = this.parse(AddonInfoCommand)
-
     if (err instanceof HTTPError) {
       if (err.statusCode === 404) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
+        this.error('Add-on is not a Borealis Isolated Postgres add-on')
       } else {
         this.error('Add-on service is temporarily unavailable. Try again later.')
       }

--- a/src/commands/borealis-pg/psql.test.ts
+++ b/src/commands/borealis-pg/psql.test.ts
@@ -605,14 +605,6 @@ describe('interactive psql command', () => {
       verify(mockSshClientFactoryType.create()).never()
     })
 
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:psql'])
-    .catch(/^Borealis Isolated Postgres add-on could not be found/)
-    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
-
   function getTcpSocketListener(
     expectedEventName: string,
     expectedCallCount: number): (...args: unknown[]) => void {

--- a/src/commands/borealis-pg/psql.ts
+++ b/src/commands/borealis-pg/psql.ts
@@ -77,11 +77,9 @@ pgAdmin).`
       this.error(`The file "${customBinaryPath}" does not exist`)
     }
 
-    const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const addonInfo = processAddonAttachmentInfo(
-      attachmentInfos,
-      {addonOrAttachment: flags.addon, app: flags.app},
-      this.error)
+    const attachmentInfo =
+      await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app, this.error)
+    const addonInfo = processAddonAttachmentInfo(attachmentInfo, this.error)
 
     const [sshConnInfo, dbConnInfo] = await this.prepareUsers(
       addonInfo,
@@ -157,8 +155,6 @@ pgAdmin).`
   }
 
   async catch(err: any) {
-    const {flags} = this.parse(PsqlCommand)
-
     if (err instanceof HTTPError) {
       if (err.statusCode === 403) {
         this.error(
@@ -166,9 +162,9 @@ pgAdmin).`
           'Generally this indicates the database has persistently exceeded its storage limit. ' +
           'Try upgrading to a new add-on plan to restore access.')
       } else if (err.statusCode === 404) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
+        this.error('Add-on is not a Borealis Isolated Postgres add-on')
       } else if (err.statusCode === 422) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)
+        this.error('Add-on is not finished provisioning')
       } else {
         this.error('Add-on service is temporarily unavailable. Try again later.')
       }

--- a/src/commands/borealis-pg/psql.ts
+++ b/src/commands/borealis-pg/psql.ts
@@ -155,6 +155,7 @@ pgAdmin).`
   }
 
   async catch(err: any) {
+    /* istanbul ignore else */
     if (err instanceof HTTPError) {
       if (err.statusCode === 403) {
         this.error(

--- a/src/commands/borealis-pg/psql.ts
+++ b/src/commands/borealis-pg/psql.ts
@@ -52,9 +52,9 @@ in combination with any PostgreSQL client (e.g. a graphical user interface like
 pgAdmin).`
 
   static examples = [
+    `$ heroku borealis-pg:psql --${appOptionName} sushi --${binaryPathOptionName} /path/to/psql`,
+    `$ heroku borealis-pg:psql --${appOptionName} sushi --${addonOptionName} BOREALIS_PG_MAROON --${writeAccessOptionName}`,
     `$ heroku borealis-pg:psql --${addonOptionName} borealis-pg-hex-12345`,
-    `$ heroku borealis-pg:psql --${appOptionName} sushi --${addonOptionName} DATABASE --${binaryPathOptionName} /path/to/psql`,
-    `$ heroku borealis-pg:psql --${appOptionName} sushi --${addonOptionName} DATABASE_URL --${writeAccessOptionName}`,
   ]
 
   static flags = {

--- a/src/commands/borealis-pg/run.test.ts
+++ b/src/commands/borealis-pg/run.test.ts
@@ -1251,14 +1251,6 @@ describe('noninteractive run command', () => {
       verify(mockSshClientFactoryType.create()).never()
     })
 
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:run', '-e', fakeShellCommand])
-    .catch(/^Borealis Isolated Postgres add-on could not be found/)
-    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
-
   function getTcpSocketListener(
     expectedEventName: string,
     expectedCallCount: number): (...args: unknown[]) => void {

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -139,11 +139,9 @@ like pgAdmin).`
     const normalizedOutputFormat =
       (flags.format === defaultOutputFormat) ? undefined : flags.format
 
-    const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const addonInfo = processAddonAttachmentInfo(
-      attachmentInfos,
-      {addonOrAttachment: flags.addon, app: flags.app},
-      this.error)
+    const attachmentInfo =
+      await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app, this.error)
+    const addonInfo = processAddonAttachmentInfo(attachmentInfo, this.error)
 
     const [sshConnInfo, dbConnInfo] = await this.prepareUsers(
       addonInfo,
@@ -377,8 +375,6 @@ like pgAdmin).`
   }
 
   async catch(err: any) {
-    const {flags} = this.parse(RunCommand)
-
     if (err instanceof HTTPError) {
       if (err.statusCode === 403) {
         this.error(
@@ -386,9 +382,9 @@ like pgAdmin).`
           'Generally this indicates the database has persistently exceeded its storage limit. ' +
           'Try upgrading to a new add-on plan to restore access.')
       } else if (err.statusCode === 404) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
+        this.error('Add-on is not a Borealis Isolated Postgres add-on')
       } else if (err.statusCode === 422) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)
+        this.error('Add-on is not finished provisioning')
       } else {
         this.error('Add-on service is temporarily unavailable. Try again later.')
       }

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -82,9 +82,9 @@ used in combination with any PostgreSQL client (e.g. a graphical user interface
 like pgAdmin).`
 
   static examples = [
+    `$ heroku borealis-pg:run --${appOptionName} sushi --${dbCommandOptionName} 'SELECT * FROM hello_greeting' --${outputFormatOptionName} csv`,
+    `$ heroku borealis-pg:run --${appOptionName} sushi --${addonOptionName} BOREALIS_PG_MAROON --${dbCommandFileOptionName} ~/scripts/example.sql --${personalUserOptionName}`,
     `$ heroku borealis-pg:run --${addonOptionName} borealis-pg-hex-12345 --${shellCommandOptionName} './manage.py migrate' --${writeAccessOptionName}`,
-    `$ heroku borealis-pg:run --${appOptionName} sushi --${addonOptionName} DATABASE --${dbCommandOptionName} 'SELECT * FROM hello_greeting' --${outputFormatOptionName} csv`,
-    `$ heroku borealis-pg:run --${appOptionName} sushi --${addonOptionName} DATABASE_URL --${dbCommandFileOptionName} ~/scripts/example.sql --${personalUserOptionName}`,
   ]
 
   static flags = {

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -375,6 +375,7 @@ like pgAdmin).`
   }
 
   async catch(err: any) {
+    /* istanbul ignore else */
     if (err instanceof HTTPError) {
       if (err.statusCode === 403) {
         this.error(

--- a/src/commands/borealis-pg/tunnel.test.ts
+++ b/src/commands/borealis-pg/tunnel.test.ts
@@ -593,14 +593,6 @@ describe('secure tunnel command', () => {
       verify(mockSshClientFactoryType.create()).never()
     })
 
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:tunnel'])
-    .catch(/^Borealis Isolated Postgres add-on could not be found/)
-    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
-
   function getTcpSocketListener(
     expectedEventName: string,
     expectedCallCount: number): (...args: unknown[]) => void {

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -51,9 +51,9 @@ See also the ${consoleColours.cliCmdName('borealis-pg:run')} command to execute 
 ${consoleColours.cliCmdName('borealis-pg:psql')} command to launch an interactive psql session directly.`
 
   static examples = [
+    `$ heroku borealis-pg:tunnel --${appOptionName} sushi --${portOptionName} 54321`,
+    `$ heroku borealis-pg:tunnel --${appOptionName} sushi --${addonOptionName} BOREALIS_PG_MAROON`,
     `$ heroku borealis-pg:tunnel --${addonOptionName} borealis-pg-hex-12345 --${writeAccessOptionName}`,
-    `$ heroku borealis-pg:tunnel --${appOptionName} sushi --${addonOptionName} DATABASE --${portOptionName} 54321`,
-    `$ heroku borealis-pg:tunnel --${appOptionName} sushi --${addonOptionName} DATABASE_URL`,
   ]
 
   static flags = {

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -149,6 +149,7 @@ steps are required to use a graphical user interface (e.g. pgAdmin).`)
   }
 
   async catch(err: any) {
+    /* istanbul ignore else */
     if (err instanceof HTTPError) {
       if (err.statusCode === 403) {
         this.error(

--- a/src/commands/borealis-pg/tunnel.ts
+++ b/src/commands/borealis-pg/tunnel.ts
@@ -65,11 +65,9 @@ ${consoleColours.cliCmdName('borealis-pg:psql')} command to launch an interactiv
 
   async run() {
     const {flags} = this.parse(TunnelCommand)
-    const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const {addonName} = processAddonAttachmentInfo(
-      attachmentInfos,
-      {addonOrAttachment: flags.addon, app: flags.app},
-      this.error)
+    const attachmentInfo =
+      await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app, this.error)
+    const {addonName} = processAddonAttachmentInfo(attachmentInfo, this.error)
 
     const [sshConnInfo, dbConnInfo] =
       await this.createPersonalUsers(addonName, flags[writeAccessOptionName])
@@ -151,8 +149,6 @@ steps are required to use a graphical user interface (e.g. pgAdmin).`)
   }
 
   async catch(err: any) {
-    const {flags} = this.parse(TunnelCommand)
-
     if (err instanceof HTTPError) {
       if (err.statusCode === 403) {
         this.error(
@@ -160,9 +156,9 @@ steps are required to use a graphical user interface (e.g. pgAdmin).`)
           'Generally this indicates the database has persistently exceeded its storage limit. ' +
           'Try upgrading to a new add-on plan to restore access.')
       } else if (err.statusCode === 404) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
+        this.error('Add-on is not a Borealis Isolated Postgres add-on')
       } else if (err.statusCode === 422) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)
+        this.error('Add-on is not finished provisioning')
       } else {
         this.error('Add-on service is temporarily unavailable. Try again later.')
       }

--- a/src/commands/borealis-pg/users/index.test.ts
+++ b/src/commands/borealis-pg/users/index.test.ts
@@ -135,12 +135,4 @@ describe('database users command', () => {
     .it('exits with an error when there is an API server error', ctx => {
       expect(ctx.stdout).to.equal('')
     })
-
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:users'])
-    .catch(/^Borealis Isolated Postgres add-on could not be found/)
-    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
 })

--- a/src/commands/borealis-pg/users/index.test.ts
+++ b/src/commands/borealis-pg/users/index.test.ts
@@ -1,8 +1,12 @@
-import color from '@heroku-cli/color'
 import {borealisPgApiBaseUrl, expect, herokuApiBaseUrl, test} from '../../../test-utils'
 
+const fakeAddonId = 'c47cc174-9509-463e-aa75-f0794c5ee595'
 const fakeAddonName = 'my-super-neat-fake-addon'
+
+const fakeAttachmentId = 'a1ea0d31-801c-4594-bdd7-b1dc0b6414fd'
 const fakeAttachmentName = 'MY_SUPER_NEAT_FAKE_ADDON'
+
+const fakeHerokuAppId = '33886793-1aa1-4cb5-988e-1614a4efc384'
 const fakeHerokuAppName = 'my-super-neat-fake-app'
 
 const fakeAppReadOnlyUsername = 'app_ro_12345'
@@ -19,7 +23,7 @@ const fakePersonalReadWriteUsername2 = 'p_rw_ghijkl'
 const fakeHerokuAuthToken = 'my-fake-heroku-auth-token'
 const fakeHerokuAuthId = 'my-fake-heroku-auth'
 
-const baseTestContext = test.stdout()
+const defaultTestContext = test.stdout()
   .stderr()
   .nock(herokuApiBaseUrl, api => api
     .post('/oauth/authorizations', {
@@ -29,19 +33,18 @@ const baseTestContext = test.stdout()
     })
     .reply(201, {id: fakeHerokuAuthId, access_token: {token: fakeHerokuAuthToken}})
     .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
-    .reply(200))
-
-const defaultTestContext = baseTestContext
-  .nock(herokuApiBaseUrl, api => api
+    .reply(200)
     .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
     .reply(200, [
       {
-        addon: {name: fakeAddonName},
-        app: {name: fakeHerokuAppName},
+        addon: {id: fakeAddonId, name: fakeAddonName},
+        app: {id: fakeHerokuAppId, name: fakeHerokuAppName},
+        id: fakeAttachmentId,
         name: fakeAttachmentName,
       },
-      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
-    ]))
+    ])
+    .get(`/addons/${fakeAddonId}`)
+    .reply(200, {addon_service: {name: 'borealis-pg'}, id: fakeAddonId, name: fakeAddonName}))
 
 describe('database users command', () => {
   defaultTestContext
@@ -74,7 +77,7 @@ describe('database users command', () => {
             ],
           }))
     .command(['borealis-pg:users', '--addon', fakeAddonName])
-    .it('displays DB users for an add-on identified by add-on name', ctx => {
+    .it('displays DB users for an add-on', ctx => {
       expect(ctx.stderr).to.contain(`Fetching user list for add-on ${fakeAddonName}... done`)
 
       expect(ctx.stdout).to.containIgnoreSpaces(
@@ -83,54 +86,6 @@ describe('database users command', () => {
         ` Heroku App User ${fakeAppReadOnlyUsername} ${fakeAppReadWriteUsername} \n` +
         ` ${fakePersonalUser1} ${fakePersonalReadOnlyUsername1} ${fakePersonalReadWriteUsername1} \n` +
         ` ${fakePersonalUser2} ${fakePersonalReadOnlyUsername2} ${fakePersonalReadWriteUsername2} \n`)
-    })
-
-  baseTestContext
-    .nock(herokuApiBaseUrl, api => api
-      .post(
-        '/actions/addon-attachments/resolve',
-        {addon_attachment: fakeAttachmentName, app: fakeHerokuAppName})
-      .reply(200, [
-        {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: fakeAttachmentName},
-      ]))
-    .nock(
-      borealisPgApiBaseUrl,
-      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
-      api => api.get(`/heroku/resources/${fakeAddonName}/db-users`)
-        .reply(
-          200,
-          {
-            users: [
-              {
-                displayName: null,
-                readOnlyUsername: fakeAppReadOnlyUsername,
-                readWriteUsername: fakeAppReadWriteUsername,
-                userType: 'app',
-              },
-              {
-                displayName: fakePersonalUser2,
-                readOnlyUsername: fakePersonalReadOnlyUsername2,
-                readWriteUsername: fakePersonalReadWriteUsername2,
-                userType: 'personal',
-              },
-              {
-                displayName: fakePersonalUser1,
-                readOnlyUsername: fakePersonalReadOnlyUsername1,
-                readWriteUsername: fakePersonalReadWriteUsername1,
-                userType: 'personal',
-              },
-            ],
-          }))
-    .command(['borealis-pg:users', '--app', fakeHerokuAppName, '--addon', fakeAttachmentName])
-    .it('displays DB users for an add-on identified by app and attachment name', ctx => {
-      expect(ctx.stderr).to.contain(`Fetching user list for add-on ${fakeAddonName}... done`)
-
-      expect(ctx.stdout).to.containIgnoreSpaces(
-        ' Add-on User             DB Read-only Username DB Read/Write Username \n' +
-        ' ─────────────────────── ───────────────────── ────────────────────── \n' +
-        ` Heroku App User ${fakeAppReadOnlyUsername} ${fakeAppReadWriteUsername} \n` +
-        ` ${fakePersonalUser2} ${fakePersonalReadOnlyUsername2} ${fakePersonalReadWriteUsername2} \n` +
-        ` ${fakePersonalUser1} ${fakePersonalReadOnlyUsername1} ${fakePersonalReadWriteUsername1} \n`)
     })
 
   defaultTestContext
@@ -145,36 +100,6 @@ describe('database users command', () => {
       expect(ctx.stderr).to.contain('No users found')
     })
 
-  test.stdout()
-    .stderr()
-    .nock(
-      herokuApiBaseUrl,
-      api => api.post('/oauth/authorizations')
-        .reply(201, {id: fakeHerokuAuthId})  // Note the access_token field is missing
-        .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
-        .reply(200)
-        .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
-        .reply(200, [
-          {
-            addon: {name: fakeAddonName},
-            app: {name: fakeHerokuAppName},
-            name: fakeAttachmentName,
-          },
-        ]))
-    .command(['borealis-pg:users', '-o', fakeAddonName])
-    .catch('Log in to the Heroku CLI first!')
-    .it('exits with an error when there is no Heroku access token', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
-
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:users'])
-    .catch(/^Missing required flag:/)
-    .it('exits with an error when there is no add-on name option', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
-
   defaultTestContext
     .nock(
       borealisPgApiBaseUrl,
@@ -182,7 +107,7 @@ describe('database users command', () => {
       api => api.get(`/heroku/resources/${fakeAddonName}/db-users`)
         .reply(404, {reason: 'Not found'}))
     .command(['borealis-pg:users', '--addon', fakeAddonName])
-    .catch(`Add-on ${color.addon(fakeAddonName)} is not a Borealis Isolated Postgres add-on`)
+    .catch('Add-on is not a Borealis Isolated Postgres add-on')
     .it('exits with an error when the add-on was not found', ctx => {
       expect(ctx.stdout).to.equal('')
     })
@@ -194,7 +119,7 @@ describe('database users command', () => {
       api => api.get(`/heroku/resources/${fakeAddonName}/db-users`)
         .reply(422, {reason: 'Not done yet'}))
     .command(['borealis-pg:users', '--addon', fakeAddonName])
-    .catch(`Add-on ${color.addon(fakeAddonName)} is not finished provisioning`)
+    .catch('Add-on is not finished provisioning')
     .it('exits with an error when the add-on is not finished provisioning', ctx => {
       expect(ctx.stdout).to.equal('')
     })
@@ -208,6 +133,14 @@ describe('database users command', () => {
     .command(['borealis-pg:users', '--addon', fakeAddonName])
     .catch('Add-on service is temporarily unavailable. Try again later.')
     .it('exits with an error when there is an API server error', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  test.stdout()
+    .stderr()
+    .command(['borealis-pg:users'])
+    .catch(/^Borealis Isolated Postgres add-on could not be found/)
+    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 })

--- a/src/commands/borealis-pg/users/index.ts
+++ b/src/commands/borealis-pg/users/index.ts
@@ -74,6 +74,7 @@ ${cliCmdColour('borealis-pg:users:reset')} command).`
   }
 
   async catch(err: any) {
+    /* istanbul ignore else */
     if (err instanceof HTTPError) {
       if (err.statusCode === 404) {
         this.error('Add-on is not a Borealis Isolated Postgres add-on')

--- a/src/commands/borealis-pg/users/index.ts
+++ b/src/commands/borealis-pg/users/index.ts
@@ -37,11 +37,9 @@ ${cliCmdColour('borealis-pg:users:reset')} command).`
   async run() {
     const {flags} = this.parse(ListUsersCommand)
     const authorization = await createHerokuAuth(this.heroku)
-    const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const {addonName} = processAddonAttachmentInfo(
-      attachmentInfos,
-      {addonOrAttachment: flags.addon, app: flags.app},
-      this.error)
+    const attachmentInfo =
+      await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app, this.error)
+    const {addonName} = processAddonAttachmentInfo(attachmentInfo, this.error)
     try {
       const response = await applyActionSpinner(
         `Fetching user list for add-on ${color.addon(addonName)}`,
@@ -76,13 +74,11 @@ ${cliCmdColour('borealis-pg:users:reset')} command).`
   }
 
   async catch(err: any) {
-    const {flags} = this.parse(ListUsersCommand)
-
     if (err instanceof HTTPError) {
       if (err.statusCode === 404) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
+        this.error('Add-on is not a Borealis Isolated Postgres add-on')
       } else if (err.statusCode === 422) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)
+        this.error('Add-on is not finished provisioning')
       } else {
         this.error('Add-on service is temporarily unavailable. Try again later.')
       }

--- a/src/commands/borealis-pg/users/reset.test.ts
+++ b/src/commands/borealis-pg/users/reset.test.ts
@@ -107,12 +107,4 @@ describe('database credentials reset command', () => {
     .it('exits with an error when there is an API server error', ctx => {
       expect(ctx.stdout).to.equal('')
     })
-
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:users:reset'])
-    .catch(/^Borealis Isolated Postgres add-on could not be found/)
-    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
 })

--- a/src/commands/borealis-pg/users/reset.test.ts
+++ b/src/commands/borealis-pg/users/reset.test.ts
@@ -1,14 +1,18 @@
-import color from '@heroku-cli/color'
 import {borealisPgApiBaseUrl, expect, herokuApiBaseUrl, test} from '../../../test-utils'
 
+const fakeAddonId = 'd04a3bfc-88d9-4787-92ef-8c8be5e3f0e0'
 const fakeAddonName = 'my-super-neat-fake-addon'
+
+const fakeAttachmentId = 'fdc2648b-6e3d-40b9-8884-bc32c8610b83'
 const fakeAttachmentName = 'MY_SUPER_NEAT_FAKE_ADDON'
+
+const fakeHerokuAppId = '47bb295d-65b9-43cd-9528-ad52aa22034e'
 const fakeHerokuAppName = 'my-super-neat-fake-app'
 
 const fakeHerokuAuthToken = 'my-fake-heroku-auth-token'
 const fakeHerokuAuthId = 'my-fake-heroku-auth'
 
-const baseTestContext = test.stdout()
+const defaultTestContext = test.stdout()
   .stderr()
   .nock(herokuApiBaseUrl, api => api
     .post('/oauth/authorizations', {
@@ -18,19 +22,18 @@ const baseTestContext = test.stdout()
     })
     .reply(201, {id: fakeHerokuAuthId, access_token: {token: fakeHerokuAuthToken}})
     .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
-    .reply(200))
-
-const defaultTestContext = baseTestContext
-  .nock(herokuApiBaseUrl, api => api
+    .reply(200)
     .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
     .reply(200, [
       {
-        addon: {name: fakeAddonName},
-        app: {name: fakeHerokuAppName},
+        addon: {id: fakeAddonId, name: fakeAddonName},
+        app: {id: fakeHerokuAppId, name: fakeHerokuAppName},
+        id: fakeAttachmentId,
         name: fakeAttachmentName,
       },
-      {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: 'DATABASE'},
-    ]))
+    ])
+    .get(`/addons/${fakeAddonId}`)
+    .reply(200, {addon_service: {name: 'borealis-pg'}, id: fakeAddonId, name: fakeAddonName}))
 
 describe('database credentials reset command', () => {
   defaultTestContext
@@ -40,58 +43,9 @@ describe('database credentials reset command', () => {
       api => api.delete(`/heroku/resources/${fakeAddonName}/db-users/credentials`)
         .reply(200, {}))
     .command(['borealis-pg:users:reset', '--addon', fakeAddonName])
-    .it('resets all DB credentials for an add-on identified by add-on name', ctx => {
+    .it('resets all DB credentials for an add-on', ctx => {
       expect(ctx.stderr).to.contain(
         `Resetting all database credentials for add-on ${fakeAddonName}... done`)
-    })
-
-  baseTestContext
-    .nock(herokuApiBaseUrl, api => api
-      .post(
-        '/actions/addon-attachments/resolve',
-        {addon_attachment: fakeAttachmentName, app: fakeHerokuAppName})
-      .reply(200, [
-        {addon: {name: fakeAddonName}, app: {name: fakeHerokuAppName}, name: fakeAttachmentName},
-      ]))
-    .nock(
-      borealisPgApiBaseUrl,
-      {reqheaders: {authorization: `Bearer ${fakeHerokuAuthToken}`}},
-      api => api.delete(`/heroku/resources/${fakeAddonName}/db-users/credentials`)
-        .reply(200, {}))
-    .command(['borealis-pg:users:reset', '--app', fakeHerokuAppName, '--addon', fakeAttachmentName])
-    .it('resets all DB credentials for an add-on identified by app and attachment name', ctx => {
-      expect(ctx.stderr).to.contain(
-        `Resetting all database credentials for add-on ${fakeAddonName}... done`)
-    })
-
-  test.stdout()
-    .stderr()
-    .nock(
-      herokuApiBaseUrl,
-      api => api.post('/oauth/authorizations')
-        .reply(201, {id: fakeHerokuAuthId})  // Note the access_token field is missing
-        .delete(`/oauth/authorizations/${fakeHerokuAuthId}`)
-        .reply(200)
-        .post('/actions/addon-attachments/resolve', {addon_attachment: fakeAddonName})
-        .reply(200, [
-          {
-            addon: {name: fakeAddonName},
-            app: {name: fakeHerokuAppName},
-            name: fakeAttachmentName,
-          },
-        ]))
-    .command(['borealis-pg:users:reset', '-o', fakeAddonName])
-    .catch('Log in to the Heroku CLI first!')
-    .it('exits with an error when there is no Heroku access token', ctx => {
-      expect(ctx.stdout).to.equal('')
-    })
-
-  test.stdout()
-    .stderr()
-    .command(['borealis-pg:users:reset'])
-    .catch(/^Missing required flag:/)
-    .it('exits with an error when there is no add-on name option', ctx => {
-      expect(ctx.stdout).to.equal('')
     })
 
   defaultTestContext
@@ -101,9 +55,7 @@ describe('database credentials reset command', () => {
       api => api.delete(`/heroku/resources/${fakeAddonName}/db-users/credentials`)
         .reply(400, {reason: 'Maintenance'}))
     .command(['borealis-pg:users:reset', '--addon', fakeAddonName])
-    .catch(
-      `Add-on ${color.addon(fakeAddonName)} is currently undergoing maintenance. ` +
-      'Try again in a few minutes.')
+    .catch(/^Add-on is currently undergoing maintenance/)
     .it('exits with an error when the add-on is undergoing maintenance', ctx => {
       expect(ctx.stdout).to.equal('')
     })
@@ -127,7 +79,7 @@ describe('database credentials reset command', () => {
       api => api.delete(`/heroku/resources/${fakeAddonName}/db-users/credentials`)
         .reply(404, {reason: 'Not found'}))
     .command(['borealis-pg:users:reset', '--addon', fakeAddonName])
-    .catch(`Add-on ${color.addon(fakeAddonName)} is not a Borealis Isolated Postgres add-on`)
+    .catch('Add-on is not a Borealis Isolated Postgres add-on')
     .it('exits with an error when the add-on was not found', ctx => {
       expect(ctx.stdout).to.equal('')
     })
@@ -139,7 +91,7 @@ describe('database credentials reset command', () => {
       api => api.delete(`/heroku/resources/${fakeAddonName}/db-users/credentials`)
         .reply(422, {reason: 'Not done yet'}))
     .command(['borealis-pg:users:reset', '--addon', fakeAddonName])
-    .catch(`Add-on ${color.addon(fakeAddonName)} is not finished provisioning`)
+    .catch('Add-on is not finished provisioning')
     .it('exits with an error when the add-on is not finished provisioning', ctx => {
       expect(ctx.stdout).to.equal('')
     })
@@ -153,6 +105,14 @@ describe('database credentials reset command', () => {
     .command(['borealis-pg:users:reset', '--addon', fakeAddonName])
     .catch('Add-on service is temporarily unavailable. Try again later.')
     .it('exits with an error when there is an API server error', ctx => {
+      expect(ctx.stdout).to.equal('')
+    })
+
+  test.stdout()
+    .stderr()
+    .command(['borealis-pg:users:reset'])
+    .catch(/^Borealis Isolated Postgres add-on could not be found/)
+    .it('exits with an error when neither of the add-on or app name params were received', ctx => {
       expect(ctx.stdout).to.equal('')
     })
 })

--- a/src/commands/borealis-pg/users/reset.ts
+++ b/src/commands/borealis-pg/users/reset.ts
@@ -44,11 +44,9 @@ ${formatCliOptionName('personal-user')} option).`
   async run() {
     const {flags} = this.parse(ResetUsersCommand)
     const authorization = await createHerokuAuth(this.heroku)
-    const attachmentInfos = await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app)
-    const {addonName} = processAddonAttachmentInfo(
-      attachmentInfos,
-      {addonOrAttachment: flags.addon, app: flags.app},
-      this.error)
+    const attachmentInfo =
+      await fetchAddonAttachmentInfo(this.heroku, flags.addon, flags.app, this.error)
+    const {addonName} = processAddonAttachmentInfo(attachmentInfo, this.error)
     try {
       await applyActionSpinner(
         `Resetting all database credentials for add-on ${color.addon(addonName)}`,
@@ -62,22 +60,18 @@ ${formatCliOptionName('personal-user')} option).`
   }
 
   async catch(err: any) {
-    const {flags} = this.parse(ResetUsersCommand)
-
     if (err instanceof HTTPError) {
       if (err.statusCode === 400) {
-        this.error(
-          `Add-on ${color.addon(flags.addon)} is currently undergoing maintenance. ` +
-          'Try again in a few minutes.')
+        this.error('Add-on is currently undergoing maintenance. Try again in a few minutes.')
       } else if (err.statusCode === 403) {
         this.error(
           'Write access to the add-on database has been temporarily revoked. ' +
           'Generally this indicates the database has persistently exceeded its storage limit. ' +
           'Try upgrading to a new add-on plan to restore access.')
       } else if (err.statusCode === 404) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not a Borealis Isolated Postgres add-on`)
+        this.error('Add-on is not a Borealis Isolated Postgres add-on')
       } else if (err.statusCode === 422) {
-        this.error(`Add-on ${color.addon(flags.addon)} is not finished provisioning`)
+        this.error('Add-on is not finished provisioning')
       } else {
         this.error('Add-on service is temporarily unavailable. Try again later.')
       }

--- a/src/commands/borealis-pg/users/reset.ts
+++ b/src/commands/borealis-pg/users/reset.ts
@@ -60,6 +60,7 @@ ${formatCliOptionName('personal-user')} option).`
   }
 
   async catch(err: any) {
+    /* istanbul ignore else */
     if (err instanceof HTTPError) {
       if (err.statusCode === 400) {
         this.error('Add-on is currently undergoing maintenance. Try again in a few minutes.')

--- a/src/heroku-api.test.ts
+++ b/src/heroku-api.test.ts
@@ -1,10 +1,13 @@
+import color from '@heroku-cli/color'
 import {APIClient} from '@heroku-cli/command'
 import {HerokuAPIError} from '@heroku-cli/command/lib/api-client'
-import {AddOnAttachment, OAuthAuthorization} from '@heroku-cli/schema'
+import {AddOn, AddOnAttachment, OAuthAuthorization} from '@heroku-cli/schema'
 import HTTP, {HTTPError} from 'http-call'
 import {anyString, anything, deepEqual, instance, mock, verify, when} from 'ts-mockito'
 import {createHerokuAuth, fetchAddonAttachmentInfo, removeHerokuAuth} from './heroku-api'
 import {expect} from './test-utils'
+
+const cliOptionColour = color.bold.italic
 
 describe('createHerokuAuth', () => {
   const fakeAuthorization = {id: 'my-authorization', access_token: {token: 'my-auth-token'}}
@@ -41,108 +44,458 @@ describe('createHerokuAuth', () => {
 })
 
 describe('fetchAddonAttachmentInfo', () => {
-  const fakeAddonName = 'my-good-addon'
-  const fakeAppName = 'my-neat-app'
-  const fakeAddonAttachmentName = 'MY_GREAT_DB'
+  const fakeAppId = '615c0300-fedb-445c-983a-d0d17c8cd588'
+  const fakeAppName = 'my-cool-app'
 
-  let fakeSuccessResponse: HTTP<AddOnAttachment>
+  const fakeAddonId = '8e35dbfe-cb03-4a5d-b883-c286d228e7ab'
+  const fakeAddonName = 'my-good-addon'
+  const fakeAddonInfo: AddOn = {
+    addon_service: {name: 'borealis-pg'},
+    app: {id: fakeAppId, name: fakeAppName},
+    id: fakeAddonId,
+    name: fakeAddonName,
+  }
+
+  const fakeAddonAttachmentId = '09bb17cd-958d-443c-bb39-fcb51f693eba'
+  const fakeAddonAttachmentName = 'MY_GREAT_DB'
+  const fakeAddonAttachment: AddOnAttachment = {
+    addon: {app: {}, id: fakeAddonId, name: fakeAddonName},
+    app: {id: fakeAppId, name: fakeAppName},
+    id: fakeAddonAttachmentId,
+    name: fakeAddonAttachmentName,
+  }
+
+  let errorHandlerMockType: {func: ((message: string) => never)}
+  let errorHandlerMockInstance: typeof errorHandlerMockType
+
+  let fakeAttachmentsResolveSuccessResponse: HTTP<AddOnAttachment[]>
+  let fakeAttachmentsListSuccessResponse: HTTP<AddOnAttachment[]>
+  let fakeAddonInfoSuccessResponse: HTTP<AddOn>
+  let fakeAddonListSuccessResponse: HTTP<AddOn[]>
 
   let mockHerokuApiClientType: APIClient
   let mockHerokuApiClientInstance: APIClient
 
   beforeEach(() => {
-    fakeSuccessResponse = new HTTP<AddOnAttachment>('https://api.borealis-data.com/foobaz')
+    errorHandlerMockType = mock()
+    when(errorHandlerMockType.func(anything())).thenThrow(new Error('Invalid'))
+    errorHandlerMockInstance = instance(errorHandlerMockType)
+
+    fakeAttachmentsResolveSuccessResponse =
+      new HTTP<AddOnAttachment[]>('https://borealis-data.example.com/attachments-resolve')
+    fakeAttachmentsListSuccessResponse =
+      new HTTP<AddOnAttachment[]>('https://borealis-data.example.com/attachments-list')
+    fakeAddonInfoSuccessResponse = new HTTP<AddOn>('https://borealis-data.example.com/addon')
+    fakeAddonListSuccessResponse = new HTTP<AddOn[]>('https://borealis-data.example.com/addons')
 
     mockHerokuApiClientType = mock()
-    when(mockHerokuApiClientType.post<AddOnAttachment>(anyString(), anything()))
-      .thenResolve(fakeSuccessResponse)
+    when(
+      mockHerokuApiClientType.post<AddOnAttachment[]>(
+        '/actions/addon-attachments/resolve',
+        anything()))
+      .thenResolve(fakeAttachmentsResolveSuccessResponse)
+    when(mockHerokuApiClientType.get<AddOnAttachment[]>(`/addons/${fakeAddonId}/addon-attachments`))
+      .thenResolve(fakeAttachmentsListSuccessResponse)
+    when(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`))
+      .thenResolve(fakeAddonInfoSuccessResponse)
+    when(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`))
+      .thenResolve(fakeAddonListSuccessResponse)
 
     mockHerokuApiClientInstance = instance(mockHerokuApiClientType)
   })
 
-  it('returns attachments for an add-on without an app name', async () => {
-    const fakeAttachments: AddOnAttachment[] = [{id: '#1'}]
-    fakeSuccessResponse.body = fakeAttachments
-
-    const results = await fetchAddonAttachmentInfo(mockHerokuApiClientInstance, fakeAddonName)
-
-    expect(results).to.deep.equal(fakeAttachments)
-
-    verify(mockHerokuApiClientType.post<AddOnAttachment>(
-      '/actions/addon-attachments/resolve',
-      deepEqual({body: {addon_attachment: fakeAddonName}})))
-      .once()
-  })
-
-  it('returns attachments for an add-on attachment and app', async () => {
-    const fakeAttachments: AddOnAttachment[] = [{id: '#2'}, {id: '#3'}]
-    fakeSuccessResponse.body = fakeAttachments
+  it('returns the attachment when there are both add-on and app name params', async () => {
+    fakeAttachmentsResolveSuccessResponse.body = [
+      {
+        addon: {app: {}, id: 'b5e7b525-b3bb-421e-8770-68c2da8b46c4', name: 'another-addon'},
+        app: {name: 'another-app'},
+        id: '66fb5336-eaf6-4e0c-8d81-0eeaf2c6ddd2',
+        name: 'ANOTHER_ATTACHMENT',
+      },
+      fakeAddonAttachment,
+    ]
+    fakeAddonInfoSuccessResponse.body = fakeAddonInfo
 
     const results = await fetchAddonAttachmentInfo(
       mockHerokuApiClientInstance,
       fakeAddonAttachmentName,
-      fakeAppName)
+      fakeAppName,
+      errorHandlerMockInstance.func)
 
-    expect(results).to.deep.equal(fakeAttachments)
+    expect(results).to.deep.equal(fakeAddonAttachment)
 
-    verify(mockHerokuApiClientType.post<AddOnAttachment>(
-      '/actions/addon-attachments/resolve',
-      deepEqual({body: {addon_attachment: fakeAddonAttachmentName, app: fakeAppName}})))
+    verify(errorHandlerMockType.func(anything())).never()
+
+    verify(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        deepEqual({body: {addon_attachment: fakeAddonAttachmentName, app: fakeAppName}})))
       .once()
+    verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).once()
+    verify(
+      mockHerokuApiClientType.get<AddOnAttachment[]>(
+        `/addons/${fakeAddonId}/addon-attachments`))
+      .never()
+    verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
   })
 
-  it('returns null for a 404 response', async () => {
-    const fakeHttp404Response: any = {body: {message: 'Not found'}, statusCode: 404}
+  it('returns the first attachment when there is no app name param', async () => {
+    fakeAttachmentsResolveSuccessResponse.body = [
+      fakeAddonAttachment,
+      {
+        addon: {app: {}, id: 'ec95a73e-f166-4763-b094-723a43a9b474', name: 'some-other-addon'},
+        app: {name: 'some-other-app'},
+        id: '6d380ce7-3e78-4b9d-8aac-7f1ca7293b82',
+        name: 'SOME_OTHER_ATTACHMENT',
+      },
+      {
+        addon: {app: {}, id: '43181831-c9aa-4e53-ae63-01f7603867cb', name: 'wrong-addon'},
+        id: 'e14c1a14-673d-4cd7-a9cb-a1f110d5fd86',
+        name: 'WRONG_ATTACHMENT',
+      },
+    ]
+    fakeAddonInfoSuccessResponse.body = fakeAddonInfo
 
-    mockHerokuApiClientType = mock()
-    when(mockHerokuApiClientType.post<AddOnAttachment>(anyString(), anything()))
+    const results = await fetchAddonAttachmentInfo(
+      mockHerokuApiClientInstance,
+      fakeAddonName,
+      null,
+      errorHandlerMockInstance.func)
+
+    expect(results).to.deep.equal(fakeAddonAttachment)
+
+    verify(errorHandlerMockType.func(anything())).never()
+
+    verify(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        deepEqual({body: {addon_attachment: fakeAddonName}})))
+      .once()
+    verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).once()
+    verify(
+      mockHerokuApiClientType.get<AddOnAttachment[]>(
+        `/addons/${fakeAddonId}/addon-attachments`))
+      .never()
+    verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
+  })
+
+  it('returns the attachment when there is no add-on/attachment param', async () => {
+    fakeAddonListSuccessResponse.body = [
+      {
+        addon_service: {name: 'different-addon-type'},
+        id: '80749abd-722d-4b08-ad96-5aec268397f6',
+        name: 'different-addon',
+      },
+      {
+        app: {id: '88fc7097-0a97-4088-87c3-43d73bbd78f9', name: 'incorrect-app'},
+        id: '16a60c67-afae-448c-9cb7-54b9bdcaf9c5',
+        name: 'incorrect-addon',
+      },
+      fakeAddonInfo,
+    ]
+    fakeAttachmentsListSuccessResponse.body = [
+      fakeAddonAttachment,
+      {
+        addon: {app: {}, id: '80749abd-722d-4b08-ad96-5aec268397f6', name: 'different-addon'},
+        app: {name: 'different-app'},
+        id: '5111807e-7bad-4af7-ae2a-393319348c01',
+        name: 'DIFFERENT_ATTACHMENT',
+      },
+    ]
+
+    const results = await fetchAddonAttachmentInfo(
+      mockHerokuApiClientInstance,
+      null,
+      fakeAppName,
+      errorHandlerMockInstance.func)
+
+    expect(results).to.deep.equal(fakeAddonAttachment)
+
+    verify(errorHandlerMockType.func(anything())).never()
+
+    verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).once()
+    verify(
+      mockHerokuApiClientType.get<AddOnAttachment[]>(
+        `/addons/${fakeAddonId}/addon-attachments`))
+      .once()
+    verify(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        deepEqual({body: {addon_attachment: fakeAddonName}})))
+      .never()
+    verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
+  })
+
+  it('throws an error when neither add-on nor app name params are provided', async () => {
+    return expect(
+      fetchAddonAttachmentInfo(
+        mockHerokuApiClientInstance,
+        null,
+        null,
+        errorHandlerMockInstance.func)).to.be.rejected
+      .and.then(() => {
+        verify(
+          errorHandlerMockType.func(
+            'Borealis Isolated Postgres add-on could not be found. ' +
+              `Try again with the ${cliOptionColour('--app')} and/or ` +
+              `${cliOptionColour('--addon')} options.`,
+          ))
+          .once()
+
+        verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).never()
+        verify(
+          mockHerokuApiClientType.get<AddOnAttachment[]>(
+            `/addons/${fakeAddonId}/addon-attachments`))
+          .never()
+        verify(
+          mockHerokuApiClientType.post<AddOnAttachment>(
+            '/actions/addon-attachments/resolve',
+            deepEqual({body: {addon_attachment: fakeAddonName}})))
+          .never()
+        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
+      })
+  })
+
+  it('throws an error when the add-on is from the wrong add-on service', async () => {
+    fakeAttachmentsResolveSuccessResponse.body = [fakeAddonAttachment]
+    fakeAddonInfoSuccessResponse.body = {
+      addon_service: {name: 'something-something'},
+      app: {id: fakeAppId, name: fakeAppName},
+      id: fakeAddonId,
+      name: fakeAddonName,
+    }
+
+    return expect(
+      fetchAddonAttachmentInfo(
+        mockHerokuApiClientInstance,
+        fakeAddonAttachmentName,
+        fakeAppName,
+        errorHandlerMockInstance.func)).to.be.rejected
+      .and.then(() => {
+        verify(errorHandlerMockType.func(
+          `Add-on ${color.addon(fakeAddonName)} is not a Borealis Isolated Postgres add-on`)).once()
+
+        verify(
+          mockHerokuApiClientType.post<AddOnAttachment>(
+            '/actions/addon-attachments/resolve',
+            deepEqual({body: {addon_attachment: fakeAddonAttachmentName, app: fakeAppName}})))
+          .once()
+        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).once()
+        verify(
+          mockHerokuApiClientType.get<AddOnAttachment[]>(
+            `/addons/${fakeAddonId}/addon-attachments`))
+          .never()
+        verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
+      })
+  })
+
+  it('throws an error when there are no compatible add-ons attached to an app', async () => {
+    fakeAddonListSuccessResponse.body = [
+      {
+        addon_service: {name: 'other-addon-type'},
+        id: '16d7c3b4-1815-4fa9-80a9-cc9f193fec5b',
+        name: 'other-addon',
+      },
+      {
+        addon_service: {name: 'incompatible-addon-type'},
+        id: '74b79cd5-3a6d-451c-ad6d-ccd4762832d6',
+        name: 'incompatible-addon',
+      },
+    ]
+
+    return expect(
+      fetchAddonAttachmentInfo(
+        mockHerokuApiClientInstance,
+        null,
+        fakeAppName,
+        errorHandlerMockInstance.func)).to.be.rejected
+      .and.then(() => {
+        verify(
+          errorHandlerMockType.func(
+            `App ${color.app(fakeAppName)} has no Borealis Isolated Postgres add-on attachments`))
+          .once()
+
+        verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).once()
+        verify(
+          mockHerokuApiClientType.get<AddOnAttachment[]>(
+            `/addons/${fakeAddonId}/addon-attachments`))
+          .never()
+        verify(
+          mockHerokuApiClientType.post<AddOnAttachment>(
+            '/actions/addon-attachments/resolve',
+            deepEqual({body: {addon_attachment: fakeAddonName}})))
+          .never()
+        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
+      })
+  })
+
+  it('throws an error when there are multiple compatible add-ons attached to an app', async () => {
+    fakeAddonListSuccessResponse.body = [
+      fakeAddonInfo,
+      {
+        addon_service: {name: 'something-else-addon-type'},
+        id: 'b85e5a0b-00e4-42cd-9d26-137a165beca0',
+        name: 'something-else-addon',
+      },
+      {
+        addon_service: {name: 'borealis-pg'},
+        id: 'a41d2243-2212-4d2c-b692-3bf0c7dbfa6f',
+        name: 'other-borealis-addon',
+      },
+    ]
+
+    return expect(
+      fetchAddonAttachmentInfo(
+        mockHerokuApiClientInstance,
+        null,
+        fakeAppName,
+        errorHandlerMockInstance.func)).to.be.rejected
+      .and.then(() => {
+        verify(
+          errorHandlerMockType.func(
+            `App ${color.app(fakeAppName)} has multiple Borealis Isolated Postgres add-on ` +
+            `attachments. Try again with the ${cliOptionColour('--addon')} option to specify one.`))
+          .once()
+
+        verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).once()
+        verify(
+          mockHerokuApiClientType.get<AddOnAttachment[]>(
+            `/addons/${fakeAddonId}/addon-attachments`))
+          .never()
+        verify(
+          mockHerokuApiClientType.post<AddOnAttachment>(
+            '/actions/addon-attachments/resolve',
+            deepEqual({body: {addon_attachment: fakeAddonName}})))
+          .never()
+        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
+      })
+  })
+
+  it('throws an error when the attachment does not exist on the specified app', async () => {
+    const fakeHttp404Response: any = {body: {message: 'Not found'}, statusCode: 404}
+    when(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        anything()))
       .thenReject(new HerokuAPIError(new HTTPError(fakeHttp404Response)))
 
-    mockHerokuApiClientInstance = instance(mockHerokuApiClientType)
-
-    const results = await fetchAddonAttachmentInfo(mockHerokuApiClientInstance, fakeAddonName)
-
-    expect(results).to.be.null
-
-    verify(mockHerokuApiClientType.post<AddOnAttachment>(
-      '/actions/addon-attachments/resolve',
-      deepEqual({body: {addon_attachment: fakeAddonName}})))
-      .once()
+    return expect(
+      fetchAddonAttachmentInfo(
+        mockHerokuApiClientInstance,
+        fakeAddonAttachmentName,
+        fakeAppName,
+        errorHandlerMockInstance.func)).to.be.rejected
+      .and.then(() => {
+        verify(
+          mockHerokuApiClientType.post<AddOnAttachment>(
+            '/actions/addon-attachments/resolve',
+            deepEqual({body: {addon_attachment: fakeAddonAttachmentName, app: fakeAppName}})))
+          .once()
+        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
+        verify(
+          mockHerokuApiClientType.get<AddOnAttachment[]>(
+            `/addons/${fakeAddonId}/addon-attachments`))
+          .never()
+        verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
+      })
   })
 
-  it('throws an error for a server error', async () => {
-    const fakeHttp500Response: any = {body: {message: 'Server error!'}, statusCode: 500}
+  it('throws an error when the add-on does not exist on an unspecified app', async () => {
+    const fakeHttp404Response: any = {body: {message: 'Not found'}, statusCode: 404}
+    when(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        anything()))
+      .thenReject(new HerokuAPIError(new HTTPError(fakeHttp404Response)))
 
-    mockHerokuApiClientType = mock()
-    when(mockHerokuApiClientType.post<AddOnAttachment>(anyString(), anything()))
-      .thenReject(new HerokuAPIError(new HTTPError(fakeHttp500Response)))
+    return expect(
+      fetchAddonAttachmentInfo(
+        mockHerokuApiClientInstance,
+        fakeAddonName,
+        null,
+        errorHandlerMockInstance.func)).to.be.rejected
+      .and.then(() => {
+        verify(errorHandlerMockType.func(
+          `Add-on ${color.addon(fakeAddonName)} was not found. Consider trying again ` +
+          `with the ${cliOptionColour('--app')} option.`)).once()
 
-    mockHerokuApiClientInstance = instance(mockHerokuApiClientType)
-
-    expect(fetchAddonAttachmentInfo(mockHerokuApiClientInstance, fakeAddonName))
-      .to
-      .be
-      .rejectedWith(HerokuAPIError)
-
-    verify(mockHerokuApiClientType.post<AddOnAttachment>(
-      '/actions/addon-attachments/resolve',
-      deepEqual({body: {addon_attachment: fakeAddonName}})))
-      .once()
+        verify(
+          mockHerokuApiClientType.post<AddOnAttachment>(
+            '/actions/addon-attachments/resolve',
+            deepEqual({body: {addon_attachment: fakeAddonName}})))
+          .once()
+        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
+        verify(
+          mockHerokuApiClientType.get<AddOnAttachment[]>(
+            `/addons/${fakeAddonId}/addon-attachments`))
+          .never()
+        verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
+      })
   })
 
-  it('throws an error for a client error', async () => {
-    mockHerokuApiClientType = mock()
-    when(mockHerokuApiClientType.post<AddOnAttachment>(anyString(), anything()))
-      .thenReject(new Error('error'))
+  it('throws an error when the app does not exist', async () => {
+    const fakeHttp404Response: any = {body: {message: 'Not found'}, statusCode: 404}
+    when(
+      mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`))
+      .thenReject(new HerokuAPIError(new HTTPError(fakeHttp404Response)))
 
-    mockHerokuApiClientInstance = instance(mockHerokuApiClientType)
+    return expect(
+      fetchAddonAttachmentInfo(
+        mockHerokuApiClientInstance,
+        null,
+        fakeAppName,
+        errorHandlerMockInstance.func)).to.be.rejected
+      .and.then(() => {
+        verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).once()
+        verify(
+          mockHerokuApiClientType.get<AddOnAttachment[]>(
+            `/addons/${fakeAddonId}/addon-attachments`))
+          .never()
+        verify(
+          mockHerokuApiClientType.post<AddOnAttachment>(
+            '/actions/addon-attachments/resolve',
+            deepEqual({body: {addon_attachment: fakeAddonName}})))
+          .never()
+        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
+      })
+  })
 
-    expect(fetchAddonAttachmentInfo(mockHerokuApiClientInstance, fakeAddonName)).to.be.rejected
+  it('throws an error when the returned add-on and attachment info are invalid', async () => {
+    const invalidAttachmentInfo: AddOnAttachment = {
+      id: fakeAddonAttachmentId,
+      name: fakeAddonAttachmentName,
+    }
+    fakeAttachmentsResolveSuccessResponse.body = [invalidAttachmentInfo]
+    fakeAddonInfoSuccessResponse.body = {app: {id: fakeAppId, name: fakeAppName}, id: fakeAddonId}
 
-    verify(mockHerokuApiClientType.post<AddOnAttachment>(
-      '/actions/addon-attachments/resolve',
-      deepEqual({body: {addon_attachment: fakeAddonName}})))
-      .once()
+    when(mockHerokuApiClientType.get<AddOn>(`/addons/${invalidAttachmentInfo.addon?.id}`))
+      .thenResolve(fakeAddonInfoSuccessResponse)
+
+    return expect(fetchAddonAttachmentInfo(
+      mockHerokuApiClientInstance,
+      fakeAddonAttachmentName,
+      fakeAppName,
+      errorHandlerMockInstance.func)).to.be.rejected
+      .and.then(() => {
+        verify(
+          errorHandlerMockType.func(
+            `Add-on ${color.addon(fakeAddonAttachmentName)} is not a Borealis Isolated Postgres ` +
+            'add-on'))
+          .once()
+
+        verify(
+          mockHerokuApiClientType.post<AddOnAttachment>(
+            '/actions/addon-attachments/resolve',
+            deepEqual({body: {addon_attachment: fakeAddonAttachmentName, app: fakeAppName}})))
+          .once()
+        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${invalidAttachmentInfo.addon?.id}`))
+          .once()
+        verify(
+          mockHerokuApiClientType.get<AddOnAttachment[]>(
+            `/addons/${fakeAddonId}/addon-attachments`))
+          .never()
+        verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
+      })
   })
 })
 

--- a/src/heroku-api.test.ts
+++ b/src/heroku-api.test.ts
@@ -227,33 +227,32 @@ describe('fetchAddonAttachmentInfo', () => {
   })
 
   it('throws an error when neither add-on nor app name params are provided', async () => {
-    return expect(
+    await expect(
       fetchAddonAttachmentInfo(
         mockHerokuApiClientInstance,
         null,
         null,
         errorHandlerMockInstance.func)).to.be.rejected
-      .and.then(() => {
-        verify(
-          errorHandlerMockType.func(
-            'Borealis Isolated Postgres add-on could not be found. ' +
-              `Try again with the ${cliOptionColour('--app')} and/or ` +
-              `${cliOptionColour('--addon')} options.`,
-          ))
-          .once()
 
-        verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).never()
-        verify(
-          mockHerokuApiClientType.get<AddOnAttachment[]>(
-            `/addons/${fakeAddonId}/addon-attachments`))
-          .never()
-        verify(
-          mockHerokuApiClientType.post<AddOnAttachment>(
-            '/actions/addon-attachments/resolve',
-            deepEqual({body: {addon_attachment: fakeAddonName}})))
-          .never()
-        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
-      })
+    verify(
+      errorHandlerMockType.func(
+        'Borealis Isolated Postgres add-on could not be found. ' +
+            `Try again with the ${cliOptionColour('--app')} and/or ` +
+            `${cliOptionColour('--addon')} options.`,
+      ))
+      .once()
+
+    verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).never()
+    verify(
+      mockHerokuApiClientType.get<AddOnAttachment[]>(
+        `/addons/${fakeAddonId}/addon-attachments`))
+      .never()
+    verify(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        deepEqual({body: {addon_attachment: fakeAddonName}})))
+      .never()
+    verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
   })
 
   it('throws an error when the add-on is from the wrong add-on service', async () => {
@@ -265,28 +264,27 @@ describe('fetchAddonAttachmentInfo', () => {
       name: fakeAddonName,
     }
 
-    return expect(
+    await expect(
       fetchAddonAttachmentInfo(
         mockHerokuApiClientInstance,
         fakeAddonAttachmentName,
         fakeAppName,
         errorHandlerMockInstance.func)).to.be.rejected
-      .and.then(() => {
-        verify(errorHandlerMockType.func(
-          `Add-on ${color.addon(fakeAddonName)} is not a Borealis Isolated Postgres add-on`)).once()
 
-        verify(
-          mockHerokuApiClientType.post<AddOnAttachment>(
-            '/actions/addon-attachments/resolve',
-            deepEqual({body: {addon_attachment: fakeAddonAttachmentName, app: fakeAppName}})))
-          .once()
-        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).once()
-        verify(
-          mockHerokuApiClientType.get<AddOnAttachment[]>(
-            `/addons/${fakeAddonId}/addon-attachments`))
-          .never()
-        verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
-      })
+    verify(errorHandlerMockType.func(
+      `Add-on ${color.addon(fakeAddonName)} is not a Borealis Isolated Postgres add-on`)).once()
+
+    verify(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        deepEqual({body: {addon_attachment: fakeAddonAttachmentName, app: fakeAppName}})))
+      .once()
+    verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).once()
+    verify(
+      mockHerokuApiClientType.get<AddOnAttachment[]>(
+        `/addons/${fakeAddonId}/addon-attachments`))
+      .never()
+    verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
   })
 
   it('throws an error when there are no compatible add-ons attached to an app', async () => {
@@ -303,30 +301,29 @@ describe('fetchAddonAttachmentInfo', () => {
       },
     ]
 
-    return expect(
+    await expect(
       fetchAddonAttachmentInfo(
         mockHerokuApiClientInstance,
         null,
         fakeAppName,
         errorHandlerMockInstance.func)).to.be.rejected
-      .and.then(() => {
-        verify(
-          errorHandlerMockType.func(
-            `App ${color.app(fakeAppName)} has no Borealis Isolated Postgres add-on attachments`))
-          .once()
 
-        verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).once()
-        verify(
-          mockHerokuApiClientType.get<AddOnAttachment[]>(
-            `/addons/${fakeAddonId}/addon-attachments`))
-          .never()
-        verify(
-          mockHerokuApiClientType.post<AddOnAttachment>(
-            '/actions/addon-attachments/resolve',
-            deepEqual({body: {addon_attachment: fakeAddonName}})))
-          .never()
-        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
-      })
+    verify(
+      errorHandlerMockType.func(
+        `App ${color.app(fakeAppName)} has no Borealis Isolated Postgres add-on attachments`))
+      .once()
+
+    verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).once()
+    verify(
+      mockHerokuApiClientType.get<AddOnAttachment[]>(
+        `/addons/${fakeAddonId}/addon-attachments`))
+      .never()
+    verify(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        deepEqual({body: {addon_attachment: fakeAddonName}})))
+      .never()
+    verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
   })
 
   it('throws an error when there are multiple compatible add-ons attached to an app', async () => {
@@ -344,31 +341,30 @@ describe('fetchAddonAttachmentInfo', () => {
       },
     ]
 
-    return expect(
+    await expect(
       fetchAddonAttachmentInfo(
         mockHerokuApiClientInstance,
         null,
         fakeAppName,
         errorHandlerMockInstance.func)).to.be.rejected
-      .and.then(() => {
-        verify(
-          errorHandlerMockType.func(
-            `App ${color.app(fakeAppName)} has multiple Borealis Isolated Postgres add-on ` +
-            `attachments. Try again with the ${cliOptionColour('--addon')} option to specify one.`))
-          .once()
 
-        verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).once()
-        verify(
-          mockHerokuApiClientType.get<AddOnAttachment[]>(
-            `/addons/${fakeAddonId}/addon-attachments`))
-          .never()
-        verify(
-          mockHerokuApiClientType.post<AddOnAttachment>(
-            '/actions/addon-attachments/resolve',
-            deepEqual({body: {addon_attachment: fakeAddonName}})))
-          .never()
-        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
-      })
+    verify(
+      errorHandlerMockType.func(
+        `App ${color.app(fakeAppName)} has multiple Borealis Isolated Postgres add-on ` +
+          `attachments. Try again with the ${cliOptionColour('--addon')} option to specify one.`))
+      .once()
+
+    verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).once()
+    verify(
+      mockHerokuApiClientType.get<AddOnAttachment[]>(
+        `/addons/${fakeAddonId}/addon-attachments`))
+      .never()
+    verify(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        deepEqual({body: {addon_attachment: fakeAddonName}})))
+      .never()
+    verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
   })
 
   it('throws an error when the attachment does not exist on the specified app', async () => {
@@ -379,25 +375,24 @@ describe('fetchAddonAttachmentInfo', () => {
         anything()))
       .thenReject(new HerokuAPIError(new HTTPError(fakeHttp404Response)))
 
-    return expect(
+    await expect(
       fetchAddonAttachmentInfo(
         mockHerokuApiClientInstance,
         fakeAddonAttachmentName,
         fakeAppName,
         errorHandlerMockInstance.func)).to.be.rejected
-      .and.then(() => {
-        verify(
-          mockHerokuApiClientType.post<AddOnAttachment>(
-            '/actions/addon-attachments/resolve',
-            deepEqual({body: {addon_attachment: fakeAddonAttachmentName, app: fakeAppName}})))
-          .once()
-        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
-        verify(
-          mockHerokuApiClientType.get<AddOnAttachment[]>(
-            `/addons/${fakeAddonId}/addon-attachments`))
-          .never()
-        verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
-      })
+
+    verify(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        deepEqual({body: {addon_attachment: fakeAddonAttachmentName, app: fakeAppName}})))
+      .once()
+    verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
+    verify(
+      mockHerokuApiClientType.get<AddOnAttachment[]>(
+        `/addons/${fakeAddonId}/addon-attachments`))
+      .never()
+    verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
   })
 
   it('throws an error when the add-on does not exist on an unspecified app', async () => {
@@ -408,29 +403,28 @@ describe('fetchAddonAttachmentInfo', () => {
         anything()))
       .thenReject(new HerokuAPIError(new HTTPError(fakeHttp404Response)))
 
-    return expect(
+    await expect(
       fetchAddonAttachmentInfo(
         mockHerokuApiClientInstance,
         fakeAddonName,
         null,
         errorHandlerMockInstance.func)).to.be.rejected
-      .and.then(() => {
-        verify(errorHandlerMockType.func(
-          `Add-on ${color.addon(fakeAddonName)} was not found. Consider trying again ` +
-          `with the ${cliOptionColour('--app')} option.`)).once()
 
-        verify(
-          mockHerokuApiClientType.post<AddOnAttachment>(
-            '/actions/addon-attachments/resolve',
-            deepEqual({body: {addon_attachment: fakeAddonName}})))
-          .once()
-        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
-        verify(
-          mockHerokuApiClientType.get<AddOnAttachment[]>(
-            `/addons/${fakeAddonId}/addon-attachments`))
-          .never()
-        verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
-      })
+    verify(errorHandlerMockType.func(
+      `Add-on ${color.addon(fakeAddonName)} was not found. Consider trying again ` +
+      `with the ${cliOptionColour('--app')} option.`)).once()
+
+    verify(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        deepEqual({body: {addon_attachment: fakeAddonName}})))
+      .once()
+    verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
+    verify(
+      mockHerokuApiClientType.get<AddOnAttachment[]>(
+        `/addons/${fakeAddonId}/addon-attachments`))
+      .never()
+    verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
   })
 
   it('throws an error when the app does not exist', async () => {
@@ -439,25 +433,24 @@ describe('fetchAddonAttachmentInfo', () => {
       mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`))
       .thenReject(new HerokuAPIError(new HTTPError(fakeHttp404Response)))
 
-    return expect(
+    await expect(
       fetchAddonAttachmentInfo(
         mockHerokuApiClientInstance,
         null,
         fakeAppName,
         errorHandlerMockInstance.func)).to.be.rejected
-      .and.then(() => {
-        verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).once()
-        verify(
-          mockHerokuApiClientType.get<AddOnAttachment[]>(
-            `/addons/${fakeAddonId}/addon-attachments`))
-          .never()
-        verify(
-          mockHerokuApiClientType.post<AddOnAttachment>(
-            '/actions/addon-attachments/resolve',
-            deepEqual({body: {addon_attachment: fakeAddonName}})))
-          .never()
-        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
-      })
+
+    verify(mockHerokuApiClientType.get<AddOn[]>(`/apps/${fakeAppName}/addons`)).once()
+    verify(
+      mockHerokuApiClientType.get<AddOnAttachment[]>(
+        `/addons/${fakeAddonId}/addon-attachments`))
+      .never()
+    verify(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        deepEqual({body: {addon_attachment: fakeAddonName}})))
+      .never()
+    verify(mockHerokuApiClientType.get<AddOn>(`/addons/${fakeAddonId}`)).never()
   })
 
   it('throws an error when the returned add-on and attachment info are invalid', async () => {
@@ -471,31 +464,30 @@ describe('fetchAddonAttachmentInfo', () => {
     when(mockHerokuApiClientType.get<AddOn>(`/addons/${invalidAttachmentInfo.addon?.id}`))
       .thenResolve(fakeAddonInfoSuccessResponse)
 
-    return expect(fetchAddonAttachmentInfo(
+    await expect(fetchAddonAttachmentInfo(
       mockHerokuApiClientInstance,
       fakeAddonAttachmentName,
       fakeAppName,
       errorHandlerMockInstance.func)).to.be.rejected
-      .and.then(() => {
-        verify(
-          errorHandlerMockType.func(
-            `Add-on ${color.addon(fakeAddonAttachmentName)} is not a Borealis Isolated Postgres ` +
-            'add-on'))
-          .once()
 
-        verify(
-          mockHerokuApiClientType.post<AddOnAttachment>(
-            '/actions/addon-attachments/resolve',
-            deepEqual({body: {addon_attachment: fakeAddonAttachmentName, app: fakeAppName}})))
-          .once()
-        verify(mockHerokuApiClientType.get<AddOn>(`/addons/${invalidAttachmentInfo.addon?.id}`))
-          .once()
-        verify(
-          mockHerokuApiClientType.get<AddOnAttachment[]>(
-            `/addons/${fakeAddonId}/addon-attachments`))
-          .never()
-        verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
-      })
+    verify(
+      errorHandlerMockType.func(
+        `Add-on ${color.addon(fakeAddonAttachmentName)} is not a Borealis Isolated Postgres ` +
+            'add-on'))
+      .once()
+
+    verify(
+      mockHerokuApiClientType.post<AddOnAttachment>(
+        '/actions/addon-attachments/resolve',
+        deepEqual({body: {addon_attachment: fakeAddonAttachmentName, app: fakeAppName}})))
+      .once()
+    verify(mockHerokuApiClientType.get<AddOn>(`/addons/${invalidAttachmentInfo.addon?.id}`))
+      .once()
+    verify(
+      mockHerokuApiClientType.get<AddOnAttachment[]>(
+        `/addons/${fakeAddonId}/addon-attachments`))
+      .never()
+    verify(mockHerokuApiClientType.get<AddOn[]>(`/addons/${fakeAppId}/addons`)).never()
   })
 })
 

--- a/src/heroku-api.ts
+++ b/src/heroku-api.ts
@@ -104,13 +104,12 @@ async function fetchAttachmentByAddonOrAttachment(
 async function fetchAttachmentByAppNameOnly(
   herokuApiClient: APIClient,
   appName: string,
-  errorHandler: (message: string) => never) {
+  errorHandler: (message: string) => never): Promise<AddOnAttachment | never> {
   const addonsResponse = await herokuApiClient.get<AddOn[]>(`/apps/${appName}/addons`)
-  const addonInfos = addonsResponse.body.filter(
-    addonInfo => addonInfo.addon_service?.name === addonServiceName)
+  const addonInfos = addonsResponse.body.filter(addonInfo =>
+    addonInfo.addon_service?.name === addonServiceName)
   if (addonInfos.length === 0) {
-    errorHandler(
-      `App ${color.app(appName)} has no Borealis Isolated Postgres add-on attachments`)
+    errorHandler(`App ${color.app(appName)} has no Borealis Isolated Postgres add-on attachments`)
   } else if (addonInfos.length > 1) {
     errorHandler(
       `App ${color.app(appName)} has multiple Borealis Isolated Postgres add-on attachments. ` +
@@ -119,6 +118,13 @@ async function fetchAttachmentByAppNameOnly(
     const attachmentsResponse = await herokuApiClient.get<AddOnAttachment[]>(
       `/addons/${addonInfos[0].id}/addon-attachments`)
 
-    return attachmentsResponse.body[0]
+    const attachmentInfoMatch = attachmentsResponse.body.find(attachmentInfo =>
+      attachmentInfo.app?.name === appName)
+
+    if (attachmentInfoMatch) {
+      return attachmentInfoMatch
+    } else {
+      errorHandler(`App ${color.app(appName)} has no Borealis Isolated Postgres add-on attachments`)
+    }
   }
 }

--- a/src/heroku-api.ts
+++ b/src/heroku-api.ts
@@ -1,12 +1,15 @@
+import color from '@heroku-cli/color'
 import {APIClient} from '@heroku-cli/command'
-import {AddOnAttachment, OAuthAuthorization} from '@heroku-cli/schema'
+import {AddOn, AddOnAttachment, OAuthAuthorization} from '@heroku-cli/schema'
 import {HTTPError} from 'http-call'
+import {addonOptionName, appOptionName, formatCliOptionName} from './command-components'
+
+const addonServiceName = 'borealis-pg'
 
 /**
  * Creates a new, short-lived Heroku OAuth authorization
  *
  * @param herokuApiClient The Heroku API client
- * @param includeIdentityScope Whether the authorization should include the "identity" scope
  */
 export async function createHerokuAuth(herokuApiClient: APIClient): Promise<OAuthAuthorization> {
   const response = await herokuApiClient.post<OAuthAuthorization>(
@@ -23,36 +26,6 @@ export async function createHerokuAuth(herokuApiClient: APIClient): Promise<OAut
 }
 
 /**
- * Retrieves add-on attachment info for the specified add-on or attachment.
- *
- * @param herokuApiClient The Heroku API client
- * @param addonOrAttachment The name or ID of an add-on or its attachment
- * @param appName The name of an app to which the add-on is attached
- */
-export async function fetchAddonAttachmentInfo(
-  herokuApiClient: APIClient,
-  addonOrAttachment: string,
-  appName?: string): Promise<AddOnAttachment[] | null> {
-  const baseRequestBody = {addon_attachment: addonOrAttachment}
-  const requestBody = appName ? {app: appName, ...baseRequestBody} : baseRequestBody
-
-  try {
-    const response = await herokuApiClient.post<AddOnAttachment[]>(
-      '/actions/addon-attachments/resolve',
-      {body: requestBody})
-
-    return response.body
-  } catch (error: any) {
-    const actualError = (error.http instanceof HTTPError) ? error.http : error
-    if (actualError instanceof HTTPError && actualError.statusCode === 404) {
-      return null
-    } else {
-      throw error
-    }
-  }
-}
-
-/**
  * Removes a Heroku OAuth authorization
  *
  * @param herokuApiClient The Heroku API client
@@ -60,4 +33,92 @@ export async function fetchAddonAttachmentInfo(
  */
 export async function removeHerokuAuth(herokuApiClient: APIClient, authId: string) {
   await herokuApiClient.delete<OAuthAuthorization>(`/oauth/authorizations/${authId}`)
+}
+
+/**
+ * Retrieves add-on attachment info for the specified add-on or attachment.
+ *
+ * @param herokuApiClient The Heroku API client
+ * @param addonOrAttachment The name or ID of an add-on or its attachment
+ * @param appName The name of an app to which the add-on is attached
+ * @param errorHandler A function to output errors when they occur
+ */
+export async function fetchAddonAttachmentInfo(
+  herokuApiClient: APIClient,
+  addonOrAttachment: string | null | undefined,
+  appName: string | null | undefined,
+  errorHandler: (message: string) => never): Promise<AddOnAttachment | never> {
+  if (addonOrAttachment) {
+    return fetchAttachmentByAddonOrAttachment(
+      herokuApiClient,
+      addonOrAttachment,
+      appName,
+      errorHandler)
+  } else if (appName) {
+    return fetchAttachmentByAppNameOnly(herokuApiClient, appName, errorHandler)
+  } else {
+    errorHandler(
+      'Borealis Isolated Postgres add-on could not be found. ' +
+      `Try again with the ${formatCliOptionName(appOptionName)} and/or ` +
+      `${formatCliOptionName(addonOptionName)} options.`)
+  }
+}
+
+async function fetchAttachmentByAddonOrAttachment(
+  herokuApiClient: APIClient,
+  addonOrAttachment: string,
+  appName: string | null | undefined,
+  errorHandler: (message: string) => never): Promise<AddOnAttachment | never> {
+  const baseAttachmentsRequestBody = {addon_attachment: addonOrAttachment}
+  const attachmentsRequestBody =
+    appName ? {app: appName, ...baseAttachmentsRequestBody} : baseAttachmentsRequestBody
+  try {
+    const attachmentsResponse = await herokuApiClient.post<AddOnAttachment[]>(
+      '/actions/addon-attachments/resolve',
+      {body: attachmentsRequestBody})
+    const attachmentInfo =
+      attachmentsResponse.body.find(attachmentInfo => attachmentInfo.app?.name === appName) ??
+      attachmentsResponse.body[0]
+
+    const addonResponse = await herokuApiClient.get<AddOn>(`/addons/${attachmentInfo.addon?.id}`)
+    const addonInfo = addonResponse.body
+    if (addonInfo.addon_service?.name === addonServiceName) {
+      return attachmentInfo
+    } else {
+      errorHandler(
+        `Add-on ${color.addon(addonInfo.name ?? addonOrAttachment)} is not a Borealis Isolated ` +
+        'Postgres add-on')
+    }
+  } catch (error: any) {
+    const actualError = (error.http instanceof HTTPError) ? error.http : error
+    if (!appName && actualError instanceof HTTPError && actualError.statusCode === 404) {
+      errorHandler(
+        `Add-on ${color.addon(addonOrAttachment)} was not found. Consider trying again ` +
+        `with the ${formatCliOptionName(appOptionName)} option.`)
+    } else {
+      throw error
+    }
+  }
+}
+
+async function fetchAttachmentByAppNameOnly(
+  herokuApiClient: APIClient,
+  appName: string,
+  errorHandler: (message: string) => never) {
+  const addonsResponse = await herokuApiClient.get<AddOn[]>(`/apps/${appName}/addons`)
+  const addonInfos = addonsResponse.body.filter(
+    addonInfo => addonInfo.addon_service?.name === addonServiceName)
+  if (addonInfos.length === 0) {
+    errorHandler(
+      `App ${color.app(appName)} has no Borealis Isolated Postgres add-on attachments`)
+  } else if (addonInfos.length > 1) {
+    errorHandler(
+      `App ${color.app(appName)} has multiple Borealis Isolated Postgres add-on attachments. ` +
+      `Try again with the ${formatCliOptionName(addonOptionName)} option to specify one.`)
+  } else {
+    const attachmentsResponse = await herokuApiClient.get<AddOnAttachment[]>(
+      `/addons/${addonInfos[0].id}/addon-attachments`)
+
+    return attachmentsResponse.body[0]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,8 +866,8 @@ camelcase@^6.0.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz"
 
 caniuse-lite@^1.0.30001248:
-  version "1.0.30001312"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz"
+  version "1.0.30001376"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001376.tgz"
 
 cardinal@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
The `--addon` option is no longer required for all commands as long as the `--app` option is set and there is only one Borealis Isolated Postgres add-on for an app.

Also, previously the `expect(...).to.be.rejected*` calls in `async-actions.test.ts` weren't doing anything because they didn't return the `Promise` that it created. That has been fixed.