### PR TITLE
Overridable API base URL and add-on service name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /node_modules
 /package-lock.json
 /tmp
+.env

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",
+    "dotenv": "^16.0.1",
     "eslint": "^7.32.0",
     "eslint-config-oclif": "^4.0.0",
     "eslint-config-oclif-typescript": "^1.0.2",

--- a/src/borealis-api.ts
+++ b/src/borealis-api.ts
@@ -1,6 +1,5 @@
 import {OAuthAuthorization} from '@heroku-cli/schema'
-
-const baseUrl = 'https://pg-heroku-addon-api.borealis-data.com'
+import {borealisPgApiBaseUrl} from './command-components'
 
 /**
  * Builds a Borealis Postgres API URL
@@ -10,7 +9,7 @@ const baseUrl = 'https://pg-heroku-addon-api.borealis-data.com'
  * @returns The full URL
  */
 export function getBorealisPgApiUrl(path: string): string {
-  return path.startsWith('/') ? `${baseUrl}${path}` : `${baseUrl}/${path}`
+  return path.startsWith('/') ? `${borealisPgApiBaseUrl}${path}` : `${borealisPgApiBaseUrl}/${path}`
 }
 
 /**

--- a/src/command-components.ts
+++ b/src/command-components.ts
@@ -1,6 +1,16 @@
 import color from '@heroku-cli/color'
 import {flags} from '@heroku-cli/command'
 import {AddOnAttachment} from '@heroku-cli/schema'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+/* istanbul ignore next */
+export const addonServiceName = process.env.BOREALIS_PG_ADDON_SERVICE_NAME || 'borealis-pg'
+
+/* istanbul ignore next */
+export const borealisPgApiBaseUrl =
+  process.env.BOREALIS_PG_API_BASE_URL || 'https://pg-heroku-addon-api.borealis-data.com'
 
 export const consoleColours = {
   cliCmdName: color.italic,
@@ -13,7 +23,7 @@ export const consoleColours = {
 // The corresponding DNS A record points to 127.0.0.1, just like localhost, so the result is
 // functionally identical (the client connects to the remote server through the local port
 // forwarding tunnel) but using this domain name should result in a less odd-looking connection
-// hostname and URL than using "localhost" would from a user's perspective
+// hostname and URL from a user's perspective than using "localhost" would
 export const localPgHostname = 'pg-tunnel.borealis-data.com'
 
 export const defaultPorts = {

--- a/src/heroku-api.ts
+++ b/src/heroku-api.ts
@@ -2,9 +2,12 @@ import color from '@heroku-cli/color'
 import {APIClient} from '@heroku-cli/command'
 import {AddOn, AddOnAttachment, OAuthAuthorization} from '@heroku-cli/schema'
 import {HTTPError} from 'http-call'
-import {addonOptionName, appOptionName, formatCliOptionName} from './command-components'
-
-const addonServiceName = 'borealis-pg'
+import {
+  addonOptionName,
+  addonServiceName,
+  appOptionName,
+  formatCliOptionName,
+} from './command-components'
 
 /**
  * Creates a new, short-lived Heroku OAuth authorization

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -5,6 +5,9 @@ import globby from 'globby'
 import path from 'path'
 import {test as oclifTest} from '@oclif/test'
 
+process.env.BOREALIS_PG_ADDON_SERVICE_NAME = 'borealis-pg'
+process.env.BOREALIS_PG_API_BASE_URL = 'https://pg-heroku-addon-api.borealis-data.com'
+
 const customizedChai = chai.use(chaiString).use(chaiAsPromised)
 export const expect = customizedChai.expect
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,6 +1188,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.1.tgz#8f8f9d94876c35dac989876a5d3a82a267fdce1d"
+  integrity sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==
+
 ejs@^3.1.6:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"


### PR DESCRIPTION
Allows the presence of a `.env` file to override the values in question during development.