### PR TITLE
Load .env file regardless of working directory

### DIFF
--- a/src/command-components.ts
+++ b/src/command-components.ts
@@ -2,8 +2,9 @@ import color from '@heroku-cli/color'
 import {flags} from '@heroku-cli/command'
 import {AddOnAttachment} from '@heroku-cli/schema'
 import dotenv from 'dotenv'
+import path from 'path'
 
-dotenv.config()
+dotenv.config({path: path.join(__dirname, '..', '.env')})
 
 /* istanbul ignore next */
 export const addonServiceName = process.env.BOREALIS_PG_ADDON_SERVICE_NAME || 'borealis-pg'


### PR DESCRIPTION
The Heroku CLI allows [linking](https://devcenter.heroku.com/articles/developing-cli-plugins#installing-the-plugin) of CLI plugins for testing/development of unpublished versions. When the plugin is linked, and one exercises the plugin using `heroku borealis-pg:...`, the process's current working directory will not be that of the plugin's repo but rather the Heroku CLI. Thus, to ensure that the `.env` file is always loaded, `dotenv` is now configured to use a path relative to the source file from which it is loaded.