### PR TITLE
Dependabot increase version requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    versioning-strategy: increase
 
   # Actions used in GitHub Workflows
   - package-ecosystem: github-actions


### PR DESCRIPTION
Configures Dependabot to always increase the required version in `package.json` whenever a new dependency version is available. This is in contrast to the default where it only updates the version in `package-lock.json` unless the `package.json` version range no longer matches.