### PR TITLE
Include add-on status in add-on info output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
-## [1.0.1](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.9.0...v1.0.1)
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.0.1...HEAD)
+- Adds an add-on status field to the `borealis-pg:info` (alias: `borealis-pg`) command
+
+## [1.0.1](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.0.0...v1.0.1)
 - Fixed: Include dotenv in runtime dependencies
 
 ## [1.0.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v0.9.0...v1.0.0)

--- a/src/commands/borealis-pg/info.test.ts
+++ b/src/commands/borealis-pg/info.test.ts
@@ -75,7 +75,7 @@ describe('add-on info command', () => {
     .it('displays details of a single tenant add-on', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces(`Add-on Name: ${fakeAddonName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Status: Available')
-      expect(ctx.stdout).to.containIgnoreSpaces('Region: N. Virginia (US)')
+      expect(ctx.stdout).to.containIgnoreSpaces('Region: N. Virginia (United States)')
       expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Environment: Single Tenant')
       expect(ctx.stdout).to.containIgnoreSpaces(`PostgreSQL Version: ${fakePostgresVersion}`)
@@ -114,7 +114,7 @@ describe('add-on info command', () => {
     .it('displays details of a multi-tenant add-on', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces(`Add-on Name: ${fakeAddonName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Status: Requested')
-      expect(ctx.stdout).to.containIgnoreSpaces('Region: Ireland (EU)')
+      expect(ctx.stdout).to.containIgnoreSpaces('Region: Ireland (Europe)')
       expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Environment: Multi-tenant')
       expect(ctx.stdout).to.containIgnoreSpaces(`PostgreSQL Version: ${fakePostgresVersion}`)
@@ -233,7 +233,7 @@ describe('add-on info command', () => {
     .it('displays details when the add-on is not finished provisioning', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces(`Add-on Name: ${fakeAddonName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Status: Provisioning')
-      expect(ctx.stdout).to.containIgnoreSpaces('Region: N. Virginia (US)')
+      expect(ctx.stdout).to.containIgnoreSpaces('Region: N. Virginia (United States)')
       expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Environment: Single Tenant')
       expect(ctx.stdout).to.containIgnoreSpaces(`PostgreSQL Version: ${fakePostgresVersion}`)

--- a/src/commands/borealis-pg/info.test.ts
+++ b/src/commands/borealis-pg/info.test.ts
@@ -67,14 +67,16 @@ describe('add-on info command', () => {
             postgresVersion: fakePostgresVersion,
             region: 'us-east-1',
             replicaQuantity: 2,
+            status: 'available',
             storageComplianceDeadline: null,
             storageComplianceStatus: 'ok',
           }))
     .command(['borealis-pg:info', '--app', fakeHerokuAppName])
     .it('displays details of a single tenant add-on', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces(`Add-on Name: ${fakeAddonName}`)
-      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
+      expect(ctx.stdout).to.containIgnoreSpaces('Status: Available')
       expect(ctx.stdout).to.containIgnoreSpaces('Region: N. Virginia (US)')
+      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Environment: Single Tenant')
       expect(ctx.stdout).to.containIgnoreSpaces(`PostgreSQL Version: ${fakePostgresVersion}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Maximum Storage: 20 GiB')
@@ -104,14 +106,16 @@ describe('add-on info command', () => {
             postgresVersion: fakePostgresVersion,
             region: 'eu-west-1',
             replicaQuantity: 0,
+            status: 'requested',
             storageComplianceDeadline: null,
             storageComplianceStatus: 'proximity-warning',
           }))
     .command(['borealis-pg:info', '-a', fakeHerokuAppName])
     .it('displays details of a multi-tenant add-on', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces(`Add-on Name: ${fakeAddonName}`)
-      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
+      expect(ctx.stdout).to.containIgnoreSpaces('Status: Requested')
       expect(ctx.stdout).to.containIgnoreSpaces('Region: Ireland (EU)')
+      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Environment: Multi-tenant')
       expect(ctx.stdout).to.containIgnoreSpaces(`PostgreSQL Version: ${fakePostgresVersion}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Maximum Storage: 0.25 GiB')
@@ -142,14 +146,16 @@ describe('add-on info command', () => {
             postgresVersion: fakePostgresVersion,
             region: 'ap-southeast-2',
             replicaQuantity: 0,
+            status: 'maintenance-plan-change',
             storageComplianceDeadline: null,
             storageComplianceStatus: 'ok',
           }))
     .command(['borealis-pg', '-a', fakeHerokuAppName])
     .it('displays details when called using the borealis-pg (index) alias', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces(`Add-on Name: ${fakeAddonName}`)
-      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
+      expect(ctx.stdout).to.containIgnoreSpaces('Status: Changing add-on plan')
       expect(ctx.stdout).to.containIgnoreSpaces('Region: Sydney')
+      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Environment: Single Tenant')
       expect(ctx.stdout).to.containIgnoreSpaces(`PostgreSQL Version: ${fakePostgresVersion}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Maximum Storage: 20 GiB')
@@ -179,14 +185,16 @@ describe('add-on info command', () => {
             postgresVersion: fakePostgresVersion,
             region: 'mars-orbit-1',
             replicaQuantity: 1,
+            status: 'under-the-weather',
             storageComplianceDeadline: null,
             storageComplianceStatus: 'super-duper',
           }))
     .command(['borealis-pg:info', '-a', fakeHerokuAppName])
     .it('displays raw values for custom values in the response', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces(`Add-on Name: ${fakeAddonName}`)
-      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
+      expect(ctx.stdout).to.containIgnoreSpaces('Status: under-the-weather')
       expect(ctx.stdout).to.containIgnoreSpaces('Region: mars-orbit-1')
+      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Environment: hyper-tenant')
       expect(ctx.stdout).to.containIgnoreSpaces(`PostgreSQL Version: ${fakePostgresVersion}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Maximum Storage: 500 GiB')
@@ -217,14 +225,16 @@ describe('add-on info command', () => {
             postgresVersion: fakePostgresVersion,
             region: 'us-east-1',
             replicaQuantity: 2,
+            status: 'awaiting',
             storageComplianceDeadline: null,
             storageComplianceStatus: 'ok',
           }))
     .command(['borealis-pg:info', '-a', fakeHerokuAppName])
     .it('displays details when the add-on is not finished provisioning', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces(`Add-on Name: ${fakeAddonName}`)
-      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
+      expect(ctx.stdout).to.containIgnoreSpaces('Status: Provisioning')
       expect(ctx.stdout).to.containIgnoreSpaces('Region: N. Virginia (US)')
+      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Environment: Single Tenant')
       expect(ctx.stdout).to.containIgnoreSpaces(`PostgreSQL Version: ${fakePostgresVersion}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Maximum Storage: 20 GiB')
@@ -254,14 +264,16 @@ describe('add-on info command', () => {
             postgresVersion: fakePostgresVersion,
             region: 'ap-northeast-1',
             replicaQuantity: 0,
+            status: 'maintenance',
             storageComplianceDeadline: fakeStorageComplianceDeadline,
             storageComplianceStatus: 'violating',
           }))
     .command(['borealis-pg:info', '-a', fakeHerokuAppName])
     .it('displays details for an add-on with a storage compliance violation', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces(`Add-on Name: ${fakeAddonName}`)
-      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
+      expect(ctx.stdout).to.containIgnoreSpaces('Status: Undergoing maintenance')
       expect(ctx.stdout).to.containIgnoreSpaces('Region: Tokyo')
+      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Environment: Single Tenant')
       expect(ctx.stdout).to.containIgnoreSpaces(`PostgreSQL Version: ${fakePostgresVersion}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Maximum Storage: 20 GiB')
@@ -293,14 +305,16 @@ describe('add-on info command', () => {
             postgresVersion: fakePostgresVersion,
             region: 'eu-central-1',
             replicaQuantity: 0,
+            status: 'maintenance-revoke-db-write-access',
             storageComplianceDeadline: null,
             storageComplianceStatus: 'restricted',
           }))
     .command(['borealis-pg:info', '-a', fakeHerokuAppName])
     .it('displays details for an add-on with a storage compliance status of restricted', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces(`Add-on Name: ${fakeAddonName}`)
-      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
+      expect(ctx.stdout).to.containIgnoreSpaces('Status: Revoking DB write access')
       expect(ctx.stdout).to.containIgnoreSpaces('Region: Frankfurt')
+      expect(ctx.stdout).to.containIgnoreSpaces(`Plan Name: ${fakePlanName}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Environment: Single Tenant')
       expect(ctx.stdout).to.containIgnoreSpaces(`PostgreSQL Version: ${fakePostgresVersion}`)
       expect(ctx.stdout).to.containIgnoreSpaces('Maximum Storage: 0.60 GiB')

--- a/src/commands/borealis-pg/info.ts
+++ b/src/commands/borealis-pg/info.ts
@@ -18,8 +18,8 @@ const valueColour = consoleColours.dataFieldValue
 const bytesPerGib = 1024 * 1024 * 1024
 
 const supportedRegions: {[key: string]: string} = {
-  'us-east-1': 'N. Virginia (US)',
-  'eu-west-1': 'Ireland (EU)',
+  'us-east-1': 'N. Virginia (United States)',
+  'eu-west-1': 'Ireland (Europe)',
   'eu-central-1': 'Frankfurt',
   'ap-northeast-1': 'Tokyo',
   'ap-southeast-2': 'Sydney',

--- a/src/commands/borealis-pg/info.ts
+++ b/src/commands/borealis-pg/info.ts
@@ -31,6 +31,19 @@ const dbTenancyTypes: {[key: string]: string} = {
   shared: 'Multi-tenant',
 }
 
+const addonStatuses: {[key: string]: string} = {
+  available: 'Available',
+  awaiting: 'Provisioning',
+  configuring: 'Provisioning',
+  maintenance: 'Undergoing maintenance',
+  'maintenance-db-credentials-full-reset': 'Resetting DB credentials',
+  'maintenance-plan-change': 'Changing add-on plan',
+  'maintenance-restore-db-write-access': 'Restoring DB write access',
+  'maintenance-revoke-db-write-access': 'Revoking DB write access',
+  provisioning: 'Provisioning',
+  requested: 'Requested',
+}
+
 const storageComplianceStatuses: {[key: string]: string} = {
   ok: 'OK',
   'proximity-warning': 'Proximity Warning',
@@ -71,6 +84,7 @@ export default class AddonInfoCommand extends Command {
     const region = supportedRegions[addonInfo.region] ?? addonInfo.region
     const dbTenancyType = dbTenancyTypes[addonInfo.dbTenancyType] ?? addonInfo.dbTenancyType
 
+    const addonStatus = addonStatuses[addonInfo.status] ?? addonInfo.status
     const storageComplianceStatus =
       storageComplianceStatuses[addonInfo.storageComplianceStatus] ??
       addonInfo.storageComplianceStatus
@@ -93,8 +107,9 @@ export default class AddonInfoCommand extends Command {
 
     this.log()
     this.log(`                 ${keyColour('Add-on Name')}: ${valueColour(addonInfo.addonName)}`)
-    this.log(`                   ${keyColour('Plan Name')}: ${valueColour(addonInfo.planName)}`)
+    this.log(`                      ${keyColour('Status')}: ${valueColour(addonStatus)}`)
     this.log(`                      ${keyColour('Region')}: ${valueColour(region)}`)
+    this.log(`                   ${keyColour('Plan Name')}: ${valueColour(addonInfo.planName)}`)
     this.log(`                 ${keyColour('Environment')}: ${valueColour(dbTenancyType)}`)
     this.log(`          ${keyColour('PostgreSQL Version')}: ${valueColour(addonInfo.postgresVersion)}`)
     this.log(`             ${keyColour('Maximum Storage')}: ${valueColour(dbStorageMaxDisplay)}`)
@@ -131,6 +146,7 @@ interface AddonInfo {
   postgresVersion: string;
   region: string;
   replicaQuantity: number;
+  status: string;
   storageComplianceDeadline: string | null;
   storageComplianceStatus: string;
 }


### PR DESCRIPTION
Shows whether an add-on is available, provisioning or undergoing some form of maintenance.

Also tweaks the display names of the US and Europe regions to match the add-on's web dashboard.