### PR TITLE
Update run command config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). All notable c
 
 ## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.1.0...HEAD)
 - Support the new secure tunnel connection info config var (`DATABASE_TUNNEL_BPG_CONN_INFO`)
+- Require SSL/TLS for DB connections when using the `borealis-pg:run` command
 
 ## [1.1.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.0.1...v1.1.0)
 - Adds an add-on status field to the `borealis-pg:info` (alias: `borealis-pg`) command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.1.0...HEAD)
+- Support the new secure tunnel connection info config var (`DATABASE_TUNNEL_BPG_CONN_INFO`)
+
 ## [1.1.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.0.1...v1.1.0)
 - Adds an add-on status field to the `borealis-pg:info` (alias: `borealis-pg`) command
 

--- a/src/commands/borealis-pg/run.test.ts
+++ b/src/commands/borealis-pg/run.test.ts
@@ -413,6 +413,7 @@ describe('noninteractive run command', () => {
         database: fakePgDbName,
         user: fakePgReadonlyAppUsername,
         password: fakePgReadonlyAppPassword,
+        ssl: {rejectUnauthorized: false},
       }))).once()
 
       // Check the PG client event listeners
@@ -614,6 +615,7 @@ describe('noninteractive run command', () => {
         database: fakePgDbName,
         user: fakePgReadonlyAppUsername,
         password: fakePgReadonlyAppPassword,
+        ssl: {rejectUnauthorized: false},
       }))).once()
 
       verify(mockPgClientType.connect()).once()

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -273,6 +273,7 @@ like pgAdmin).`
           database: connInfo.db.dbName,
           user: connInfo.db.dbUsername,
           password: connInfo.db.dbPassword,
+          ssl: {rejectUnauthorized: false},
         }).on('end', () => {
           sshClient.end()
           tunnelServices.nodeProcess.exit()

--- a/src/commands/borealis-pg/run.ts
+++ b/src/commands/borealis-pg/run.ts
@@ -212,8 +212,14 @@ like pgAdmin).`
     appName: string,
     attachmentName: string,
     enableWriteAccess: boolean): Promise<DbConnectionInfo> {
-    const appConnInfoConfigVarName = `${attachmentName}_SSH_TUNNEL_BPG_CONNECTION_INFO`
+    const newConnInfoConfigVarName = `${attachmentName}_TUNNEL_BPG_CONN_INFO`
+    const obsoleteConnInfoConfigVarName = `${attachmentName}_SSH_TUNNEL_BPG_CONNECTION_INFO`
+
     const configVarsInfo = await this.heroku.get<ConfigVars>(`/apps/${appName}/config-vars`)
+    const appConnInfoConfigVarName =
+      configVarsInfo.body[newConnInfoConfigVarName] ?
+        newConnInfoConfigVarName :
+        obsoleteConnInfoConfigVarName
     const appConnInfo = configVarsInfo.body[appConnInfoConfigVarName]
 
     const dbHostVar = enableWriteAccess ? 'POSTGRES_WRITER_HOST' : 'POSTGRES_READER_HOST'


### PR DESCRIPTION
- Support the new secure tunnel connection info config var (`DATABASE_TUNNEL_BPG_CONN_INFO`)
- Require SSL/TLS for DB connections when using the `borealis-pg:run` command
