### PR TITLE
Nightly backups status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
 ## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.4.0...HEAD)
-- Shows times in the user's local time zone
+- Outputs all times in the user's local time zone
+- Shows whether nightly backups are enabled in `borealis-pg:restore:capabilities` command output
 
 ## [1.4.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.3.0...v1.4.0)
 - Adds the `borealis-pg:restore:capabilities` command to retrieve an add-on's database restore capabilities

--- a/src/commands/borealis-pg/restore/capabilities.test.ts
+++ b/src/commands/borealis-pg/restore/capabilities.test.ts
@@ -61,6 +61,7 @@ describe('database restore capabilities command', () => {
           }))
     .command(['borealis-pg:restore:capabilities', '--app', fakeHerokuAppName])
     .it('displays restore capabilities of a single tenant add-on', ctx => {
+      expect(ctx.stdout).to.containIgnoreSpaces('Nightly Backups Status: Enabled')
       expect(ctx.stdout).to.containIgnoreSpaces('Restore/Clone Supported: Yes')
       expect(ctx.stdout).to.containIgnoreSpaces(
         `Earliest Restorable Time: ${DateTime.fromISO(fakeEarliestRestorableTime).toISO()}`)
@@ -78,6 +79,7 @@ describe('database restore capabilities command', () => {
           {earliestRestorableTime: null, latestRestorableTime: null, restoreSupported: false}))
     .command(['borealis-pg:restore:capabilities', '-a', fakeHerokuAppName])
     .it('displays restore capabilities of a multi-tenant add-on', ctx => {
+      expect(ctx.stdout).to.containIgnoreSpaces('Nightly Backups Status: Enabled')
       expect(ctx.stdout).to.containIgnoreSpaces('Restore/Clone Supported: No')
       expect(ctx.stdout).to.containIgnoreSpaces('Earliest Restorable Time: N/A')
       expect(ctx.stdout).to.containIgnoreSpaces('Latest Restorable Time: N/A')
@@ -97,6 +99,7 @@ describe('database restore capabilities command', () => {
           }))
     .command(['borealis-pg:restore:info', '-a', fakeHerokuAppName])
     .it('displays restore capabilities via the borealis-pg:restore:info alias', ctx => {
+      expect(ctx.stdout).to.containIgnoreSpaces('Nightly Backups Status: Enabled')
       expect(ctx.stdout).to.containIgnoreSpaces('Restore/Clone Supported: Yes')
       expect(ctx.stdout).to.containIgnoreSpaces(
         `Earliest Restorable Time: ${DateTime.fromISO(fakeEarliestRestorableTime).toISO()}`)

--- a/src/commands/borealis-pg/restore/capabilities.ts
+++ b/src/commands/borealis-pg/restore/capabilities.ts
@@ -58,6 +58,7 @@ See the ${cliCmdColour('borealis-pg:restore:execute')} command to perform a rest
   }
 
   private async printDbRestoreInfo(dbRestoreInfo: DbRestoreInfo) {
+    const nightlyBackupsStatus = 'Enabled'
     const restoreSupportedDisplay = dbRestoreInfo.restoreSupported ? 'Yes' : 'No'
     const earliestRestoreTimeDisplay = dbRestoreInfo.earliestRestorableTime ?
       DateTime.fromISO(dbRestoreInfo.earliestRestorableTime).toISO() :
@@ -67,6 +68,7 @@ See the ${cliCmdColour('borealis-pg:restore:execute')} command to perform a rest
       'N/A'
 
     this.log()
+    this.log(`   ${keyColour('Nightly Backups Status')}: ${valueColour(nightlyBackupsStatus)}`)
     this.log(`  ${keyColour('Restore/Clone Supported')}: ${valueColour(restoreSupportedDisplay)}`)
     this.log(` ${keyColour('Earliest Restorable Time')}: ${valueColour(earliestRestoreTimeDisplay)}`)
     this.log(`   ${keyColour('Latest Restorable Time')}: ${valueColour(latestRestoreTimeDisplay)}`)


### PR DESCRIPTION
Adds an entry showing whether nightly backups are enabled to `borealis-pg:restore:capabilities` command output.