### PR TITLE
Separate fields for DB clone and restore support

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,6 +1,6 @@
 recursive: true
 reporter: spec
 require: ts-node/register
-slow: 1600
+slow: 1800
 timeout: 10000
 watch-extensions: ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.5.0...HEAD)
+- Report database clone and restore capabilities separately in `borealis-pg:restore:capabilities` output
+
 ## [1.5.0](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.4.0...v1.5.0)
 - Outputs all times in the user's local time zone
 - Shows whether nightly backups are enabled in `borealis-pg:restore:capabilities` command output

--- a/src/commands/borealis-pg/restore/capabilities.test.ts
+++ b/src/commands/borealis-pg/restore/capabilities.test.ts
@@ -55,6 +55,7 @@ describe('database restore capabilities command', () => {
         .reply(
           200,
           {
+            cloneSupported: true,
             earliestRestorableTime: fakeEarliestRestorableTime,
             latestRestorableTime: fakeLatestRestorableTime,
             restoreSupported: true,
@@ -62,7 +63,8 @@ describe('database restore capabilities command', () => {
     .command(['borealis-pg:restore:capabilities', '--app', fakeHerokuAppName])
     .it('displays restore capabilities of a single tenant add-on', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces('Nightly Backups Status: Enabled')
-      expect(ctx.stdout).to.containIgnoreSpaces('Restore/Clone Supported: Yes')
+      expect(ctx.stdout).to.containIgnoreSpaces('Clone Supported: Yes')
+      expect(ctx.stdout).to.containIgnoreSpaces('Point-in-time Restore Supported: Yes')
       expect(ctx.stdout).to.containIgnoreSpaces(
         `Earliest Restorable Time: ${DateTime.fromISO(fakeEarliestRestorableTime).toISO()}`)
       expect(ctx.stdout).to.containIgnoreSpaces(
@@ -76,11 +78,17 @@ describe('database restore capabilities command', () => {
       api => api.get(`/heroku/resources/${fakeAddonName}/restore-capabilities`)
         .reply(
           200,
-          {earliestRestorableTime: null, latestRestorableTime: null, restoreSupported: false}))
+          {
+            cloneSupported: true,
+            earliestRestorableTime: null,
+            latestRestorableTime: null,
+            restoreSupported: false,
+          }))
     .command(['borealis-pg:restore:capabilities', '-a', fakeHerokuAppName])
     .it('displays restore capabilities of a multi-tenant add-on', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces('Nightly Backups Status: Enabled')
-      expect(ctx.stdout).to.containIgnoreSpaces('Restore/Clone Supported: No')
+      expect(ctx.stdout).to.containIgnoreSpaces('Clone Supported: Yes')
+      expect(ctx.stdout).to.containIgnoreSpaces('Point-in-time Restore Supported: No')
       expect(ctx.stdout).to.containIgnoreSpaces('Earliest Restorable Time: N/A')
       expect(ctx.stdout).to.containIgnoreSpaces('Latest Restorable Time: N/A')
     })
@@ -93,6 +101,7 @@ describe('database restore capabilities command', () => {
         .reply(
           200,
           {
+            cloneSupported: false,
             earliestRestorableTime: fakeEarliestRestorableTime,
             latestRestorableTime: fakeLatestRestorableTime,
             restoreSupported: true,
@@ -100,7 +109,8 @@ describe('database restore capabilities command', () => {
     .command(['borealis-pg:restore:info', '-a', fakeHerokuAppName])
     .it('displays restore capabilities via the borealis-pg:restore:info alias', ctx => {
       expect(ctx.stdout).to.containIgnoreSpaces('Nightly Backups Status: Enabled')
-      expect(ctx.stdout).to.containIgnoreSpaces('Restore/Clone Supported: Yes')
+      expect(ctx.stdout).to.containIgnoreSpaces('Clone Supported: No')
+      expect(ctx.stdout).to.containIgnoreSpaces('Point-in-time Restore Supported: Yes')
       expect(ctx.stdout).to.containIgnoreSpaces(
         `Earliest Restorable Time: ${DateTime.fromISO(fakeEarliestRestorableTime).toISO()}`)
       expect(ctx.stdout).to.containIgnoreSpaces(

--- a/src/commands/borealis-pg/restore/capabilities.ts
+++ b/src/commands/borealis-pg/restore/capabilities.ts
@@ -21,11 +21,11 @@ export default class DbRestoreInfoCommand extends Command {
   static description =
     `shows the restore capabilities of a Borealis Isolated Postgres add-on database
 
-Single tenant add-on databases may be restored to an earlier point in time or
+Qualifying add-on databases may be restored to an earlier point in time or
 cloned. This operation outputs the earliest and latest points in time to which
-the add-on database may be restored. Note that, when an add-on database is
-cloned, it will produce a physical copy as at the current time, regardless of
-the add-on's reported latest restorable time.
+an add-on database may be restored when supported. Note that, when an add-on
+database is cloned, it will produce a physical copy as at the current time,
+regardless of the add-on's reported latest restorable time.
 
 See the ${cliCmdColour('borealis-pg:restore:execute')} command to perform a restore/clone.`
 
@@ -59,6 +59,7 @@ See the ${cliCmdColour('borealis-pg:restore:execute')} command to perform a rest
 
   private async printDbRestoreInfo(dbRestoreInfo: DbRestoreInfo) {
     const nightlyBackupsStatus = 'Enabled'
+    const cloneSupportedDisplay = dbRestoreInfo.cloneSupported ? 'Yes' : 'No'
     const restoreSupportedDisplay = dbRestoreInfo.restoreSupported ? 'Yes' : 'No'
     const earliestRestoreTimeDisplay = dbRestoreInfo.earliestRestorableTime ?
       DateTime.fromISO(dbRestoreInfo.earliestRestorableTime).toISO() as string :
@@ -68,10 +69,11 @@ See the ${cliCmdColour('borealis-pg:restore:execute')} command to perform a rest
       'N/A'
 
     this.log()
-    this.log(`   ${keyColour('Nightly Backups Status')}: ${valueColour(nightlyBackupsStatus)}`)
-    this.log(`  ${keyColour('Restore/Clone Supported')}: ${valueColour(restoreSupportedDisplay)}`)
-    this.log(` ${keyColour('Earliest Restorable Time')}: ${valueColour(earliestRestoreTimeDisplay)}`)
-    this.log(`   ${keyColour('Latest Restorable Time')}: ${valueColour(latestRestoreTimeDisplay)}`)
+    this.log(`          ${keyColour('Nightly Backups Status')}: ${valueColour(nightlyBackupsStatus)}`)
+    this.log(`                 ${keyColour('Clone Supported')}: ${valueColour(cloneSupportedDisplay)}`)
+    this.log(` ${keyColour('Point-in-time Restore Supported')}: ${valueColour(restoreSupportedDisplay)}`)
+    this.log(`        ${keyColour('Earliest Restorable Time')}: ${valueColour(earliestRestoreTimeDisplay)}`)
+    this.log(`          ${keyColour('Latest Restorable Time')}: ${valueColour(latestRestoreTimeDisplay)}`)
   }
 
   async catch(err: any) {
@@ -91,6 +93,7 @@ See the ${cliCmdColour('borealis-pg:restore:execute')} command to perform a rest
 }
 
 interface DbRestoreInfo {
+  cloneSupported: boolean;
   earliestRestorableTime: string | null;
   latestRestorableTime: string | null;
   restoreSupported: boolean;

--- a/src/commands/borealis-pg/restore/execute.ts
+++ b/src/commands/borealis-pg/restore/execute.ts
@@ -41,7 +41,7 @@ const waitOptionName = 'wait'
 export default class DbRestoreExecuteCommand extends Command {
   static description = `restores or clones a Borealis Isolated Postgres add-on database
 
-Single tenant add-on databases may be restored to an earlier point in time or
+Qualifying add-on databases may be restored to an earlier point in time or
 cloned. This operation restores/clones the add-on database into a brand new
 add-on database, leaving the original add-on database unaffected. Note that,
 when an add-on database is cloned (that is, the ${formatCliOptionName(restoreToTimeOptionName)} option is


### PR DESCRIPTION
Since only single tenant add-ons support point-in-time restoration but both single tenant and multi-tenant add-ons support cloning, the two capabilities are reported separately.