### PR TITLE
Group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
     versioning-strategy: increase
 
   # Actions used in GitHub Workflows


### PR DESCRIPTION
When there are multiple dependency updates available, they will be grouped into production and development pull requests now to reduce the pull request burden.