### PR TITLE
Preparation for 1.6.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [1.6.4](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.6.3...v1.6.4)
+- Fixed: Typing errors during build
+
 ## [1.6.3](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.6.2...v1.6.3)
 - Fixed: HTTP request timeouts when adding/removing data integrations
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ DESCRIPTION
   shows information about a Borealis Isolated Postgres add-on database
 ```
 
-_See code: [src/commands/borealis-pg/index.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/index.ts)_
+_See code: [src/commands/borealis-pg/index.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/index.ts)_
 
 ## `heroku borealis-pg:extensions`
 
@@ -72,7 +72,7 @@ DESCRIPTION
   lists installed Postgres extensions for a Borealis Isolated Postgres add-on
 ```
 
-_See code: [src/commands/borealis-pg/extensions/index.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/extensions/index.ts)_
+_See code: [src/commands/borealis-pg/extensions/index.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/extensions/index.ts)_
 
 ## `heroku borealis-pg:extensions:install PG_EXTENSION`
 
@@ -112,7 +112,7 @@ EXAMPLES
   $ heroku borealis-pg:extensions:install --suppress-conflict --addon borealis-pg-hex-12345 pg_trgm
 ```
 
-_See code: [src/commands/borealis-pg/extensions/install.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/extensions/install.ts)_
+_See code: [src/commands/borealis-pg/extensions/install.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/extensions/install.ts)_
 
 ## `heroku borealis-pg:extensions:remove PG_EXTENSION`
 
@@ -142,7 +142,7 @@ EXAMPLES
   $ heroku borealis-pg:extensions:remove --confirm uuid-ossp --addon borealis-pg-hex-12345 uuid-ossp
 ```
 
-_See code: [src/commands/borealis-pg/extensions/remove.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/extensions/remove.ts)_
+_See code: [src/commands/borealis-pg/extensions/remove.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/extensions/remove.ts)_
 
 ## `heroku borealis-pg:info`
 
@@ -160,7 +160,7 @@ DESCRIPTION
   shows information about a Borealis Isolated Postgres add-on database
 ```
 
-_See code: [src/commands/borealis-pg/info.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/info.ts)_
+_See code: [src/commands/borealis-pg/info.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/info.ts)_
 
 ## `heroku borealis-pg:integrations`
 
@@ -181,7 +181,7 @@ DESCRIPTION
   via a secure tunnel using semi-permanent SSH server and database credentials.
 ```
 
-_See code: [src/commands/borealis-pg/integrations/index.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/integrations/index.ts)_
+_See code: [src/commands/borealis-pg/integrations/index.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/integrations/index.ts)_
 
 ## `heroku borealis-pg:integrations:register SSH_PUBLIC_KEY`
 
@@ -230,7 +230,7 @@ EXAMPLES
   $ heroku borealis-pg:integrations:register --write-access --app sushi --name my_integration2 ssh-rsa SSHPUBLICKEY2===
 ```
 
-_See code: [src/commands/borealis-pg/integrations/register.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/integrations/register.ts)_
+_See code: [src/commands/borealis-pg/integrations/register.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/integrations/register.ts)_
 
 ## `heroku borealis-pg:integrations:remove`
 
@@ -258,7 +258,7 @@ EXAMPLES
   $ heroku borealis-pg:integrations:remove --confirm my_integration2 --app sushi --name my_integration2
 ```
 
-_See code: [src/commands/borealis-pg/integrations/remove.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/integrations/remove.ts)_
+_See code: [src/commands/borealis-pg/integrations/remove.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/integrations/remove.ts)_
 
 ## `heroku borealis-pg:psql`
 
@@ -308,7 +308,7 @@ EXAMPLES
   $ heroku borealis-pg:psql --addon borealis-pg-hex-12345
 ```
 
-_See code: [src/commands/borealis-pg/psql.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/psql.ts)_
+_See code: [src/commands/borealis-pg/psql.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/psql.ts)_
 
 ## `heroku borealis-pg:restore:capabilities`
 
@@ -337,7 +337,7 @@ ALIASES
   $ heroku borealis-pg:restore:info
 ```
 
-_See code: [src/commands/borealis-pg/restore/capabilities.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/restore/capabilities.ts)_
+_See code: [src/commands/borealis-pg/restore/capabilities.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/restore/capabilities.ts)_
 
 ## `heroku borealis-pg:restore:execute`
 
@@ -378,7 +378,7 @@ EXAMPLES
   $ heroku borealis-pg:restore:execute --app sushi --destination-app my-other-app --new-plan x2-s100-p2-r8
 ```
 
-_See code: [src/commands/borealis-pg/restore/execute.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/restore/execute.ts)_
+_See code: [src/commands/borealis-pg/restore/execute.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/restore/execute.ts)_
 
 ## `heroku borealis-pg:run`
 
@@ -452,7 +452,7 @@ EXAMPLES
   $ heroku borealis-pg:run --addon borealis-pg-hex-12345 --shell-cmd './manage.py migrate' --write-access
 ```
 
-_See code: [src/commands/borealis-pg/run.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/run.ts)_
+_See code: [src/commands/borealis-pg/run.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/run.ts)_
 
 ## `heroku borealis-pg:tunnel`
 
@@ -498,7 +498,7 @@ EXAMPLES
   $ heroku borealis-pg:tunnel --addon borealis-pg-hex-12345 --write-access
 ```
 
-_See code: [src/commands/borealis-pg/tunnel.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/tunnel.ts)_
+_See code: [src/commands/borealis-pg/tunnel.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/tunnel.ts)_
 
 ## `heroku borealis-pg:users`
 
@@ -526,7 +526,7 @@ DESCRIPTION
   borealis-pg:users:reset command).
 ```
 
-_See code: [src/commands/borealis-pg/users/index.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/users/index.ts)_
+_See code: [src/commands/borealis-pg/users/index.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/users/index.ts)_
 
 ## `heroku borealis-pg:users:reset`
 
@@ -565,5 +565,5 @@ DESCRIPTION
   borealis-pg:integrations:revoke command.
 ```
 
-_See code: [src/commands/borealis-pg/users/reset.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.3/src/commands/borealis-pg/users/reset.ts)_
+_See code: [src/commands/borealis-pg/users/reset.ts](https://github.com/OldSneerJaw/borealis-pg-cli/blob/v1.6.4/src/commands/borealis-pg/users/reset.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "borealis-pg-cli",
   "description": "CLI for advanced interactions with Borealis Isolated Postgres add-ons",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "author": "Boreal Information Systems Inc.",
   "bugs": "https://github.com/OldSneerJaw/borealis-pg-cli/issues",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "shx": "^0.3.4",
     "ts-mockito": "^2.6.1",
     "ts-node": "^10.9.2",
-    "typescript": "~4.4.4"
+    "typescript": "~4.9.5"
   },
   "resolutions": {
     "ansi-regex": "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5190,9 +5190,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@~4.4.4:
-  version "4.4.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz"
+typescript@~4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 undici-types@~6.19.2:
   version "6.19.8"


### PR DESCRIPTION
Updates `package.json`, the README and the CHANGELOG in preparation for the release of v1.6.4. Also includes an upgrade to the `typescript` package version to address a number of spurious type errors when running `tsc -b` to build the project.